### PR TITLE
Add custom IG support. disable tool level enable flag

### DIFF
--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/BallerinaPackageGenTool.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/BallerinaPackageGenTool.java
@@ -85,18 +85,16 @@ public class BallerinaPackageGenTool extends AbstractFHIRTool {
     private void populateEnabledIGs(ToolContext toolContext) {
 
         Map<String, IGConfig> allIgs = ((FHIRToolConfig) toolContext.getConfig()).getIgConfigs();
-        for (Map.Entry<String, IncludedIGConfig> entry : packageGenToolConfig.getIncludedIGConfigs().entrySet()) {
+        for (Map.Entry<String, IGConfig> entry : allIgs.entrySet()) {
             String igName = entry.getKey();
-            if (entry.getValue().isEnable()) {
-                FHIRImplementationGuide ig = ((FHIRSpecificationData) toolContext.getSpecificationData()).
-                        getFhirImplementationGuides().get(igName);
-                if (ig == null) {
-                    //if IG is enabled in the tool config but specification files are not available in the resources,
-                    // skip adding it and continue
-                    continue;
-                }
-                enabledIgs.put(igName, allIgs.get(igName));
+            FHIRImplementationGuide ig = ((FHIRSpecificationData) toolContext.getSpecificationData()).
+                    getFhirImplementationGuides().get(igName);
+            if (ig == null) {
+                //if IG is enabled in the tool config but specification files are not available in the resources,
+                // skip adding it and continue
+                continue;
             }
+            enabledIgs.put(igName, entry.getValue());
         }
     }
 

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/config/BallerinaPackageGenToolConfig.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/config/BallerinaPackageGenToolConfig.java
@@ -109,6 +109,9 @@ public class BallerinaPackageGenToolConfig extends AbstractToolConfig {
             case "packageConfig.org":
                 this.packageConfig.setOrg(value.getAsString());
                 break;
+            case "packageConfig.name.append":
+                this.packageConfig.setName(packageConfig.getName() + "." + value.getAsString());
+                break;
             default:
                 LOG.warn("Invalid config path: " + jsonPath);
         }

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/ResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/ResourceContextGenerator.java
@@ -76,8 +76,7 @@ public class ResourceContextGenerator {
         LOG.debug("Started: Resource Template Context population");
         for (Map.Entry<String, FHIRResourceDef> definitionEntry : ig.getResources().entrySet()) {
             StructureDefinition structureDefinition = definitionEntry.getValue().getDefinition();
-            if (definitionEntry.getValue().getDefinition().getKind().name().equalsIgnoreCase("RESOURCE") &&
-                    checkEnabledFHIRResources(structureDefinition, ig.getName())) {
+            if (definitionEntry.getValue().getDefinition().getKind().name().equalsIgnoreCase("RESOURCE")) {
 
                 this.resourceExtendedElementMap = new HashMap<>();
 
@@ -86,7 +85,6 @@ public class ResourceContextGenerator {
                 resourceTemplateContext.setResourceName(structureDefinition.getName());
                 resourceTemplateContext.setProfile(definitionEntry.getValue().getDefinition().getUrl());
                 resourceTemplateContext.setIgName(ig.getName());
-                resourceTemplateContext.setBaseIgName(toolConfig.getIncludedIGConfigs().get(ig.getName()).getBaseIGPackage());
 
                 ResourceDefinitionAnnotation resourceDefinitionAnnotation = new ResourceDefinitionAnnotation();
                 resourceDefinitionAnnotation.setName(structureDefinition.getName());
@@ -398,22 +396,6 @@ public class ResourceContextGenerator {
         this.dataTypesRegistry.add(suggestedIdentifier.toString());
         LOG.debug("Ended: Extended Element Identifier generation");
         return suggestedIdentifier.toString();
-    }
-
-    /**
-     * Check the config and filter profiles before generating
-     *
-     * @param structureDefinition FHIR structure definition
-     * @param igName              IG name
-     */
-    public boolean checkEnabledFHIRResources(StructureDefinition structureDefinition, String igName) {
-        String url = structureDefinition.getUrl();
-
-        if (this.toolConfig.getIncludedIGConfigs().get(igName).getIncludedProfiles().isEmpty()) {
-            return !this.toolConfig.getIncludedIGConfigs().get(igName).getExcludedProfiles().contains(url);
-        } else {
-            return this.toolConfig.getIncludedIGConfigs().get(igName).getIncludedProfiles().contains(url);
-        }
     }
 
     /**

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
@@ -84,7 +84,7 @@ public class HealthCmdUtils {
         }
     }
 
-    public static JsonElement getIGConfigElement(String igName, String igCode) throws BallerinaHealthException {
+    public static JsonElement getIGConfigElement(String igName, String igCode) {
 
         if (igCode != null && igCode.isEmpty()) {
             return getIGConfigElement(igName, igCode, "");

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
@@ -79,9 +79,8 @@ public class HealthCmdUtils {
     public static String generateIgDirectoryPath(String specPath, String igName) {
         if (specPath.endsWith(File.separator)) {
             return igName + File.separator;
-        } else {
-            return File.separator + igName + File.separator;
         }
+        return File.separator + igName + File.separator;
     }
 
     public static JsonElement getIGConfigElement(String igName, String igCode) {

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
@@ -1,7 +1,6 @@
 package io.ballerina.health.cmd.core.utils;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.ballerina.cli.launcher.BLauncherException;
@@ -10,6 +9,9 @@ import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Utility methods for health command.
@@ -53,35 +55,61 @@ public class HealthCmdUtils {
         return toolHome + HealthCmdConstants.CMD_RESOURCE_PATH_SUFFIX;
     }
 
-    public static String generateIgNameFromPath(String specPath) throws BallerinaHealthException {
+    public static String generateIgNameFromPath(String specPath) {
         if (specPath.contains(File.separator)) {
             //nested path given as input, last element is the IG name
             return specPath.substring(specPath.lastIndexOf(File.separator) + 1).replaceAll(
-                    " ","-").replaceAll("\\$","-");
+                    " ", "-").replaceAll("\\$", "-");
         }
-        return specPath.replaceAll(" ","-").replaceAll("\\$","-");
+        return specPath.replaceAll(" ", "-").replaceAll("\\$", "-");
     }
 
-    public static JsonElement getIGConfigElement(String igName, String igCode, String specPath) throws BallerinaHealthException {
+    public static JsonElement getIGConfigElement(String igName, String igCode, String specPath) {
 
         JsonObject igConfig = new JsonObject();
         if (igName == null || igName.isEmpty()) {
             igName = generateIgNameFromPath(specPath);
         }
         igConfig.add("name", new Gson().toJsonTree(igName));
-
-        if (igCode != null && igCode.isEmpty()) {
-            igConfig.add("code", new Gson().toJsonTree(igCode));
-        } else {
-            igConfig.add("code", new Gson().toJsonTree(igName));
-        }
+        igConfig.add("code", new Gson().toJsonTree(igCode));
         igConfig.add("dirPath", new Gson().toJsonTree(specPath));
         return igConfig;
     }
 
-    public static void throwLauncherException(Throwable error) throws BLauncherException{
+    public static String generateIgDirectoryPath(String specPath, String igName) {
+        if (specPath.endsWith(File.separator)) {
+            return igName + File.separator;
+        } else {
+            return File.separator + igName + File.separator;
+        }
+    }
+
+    public static JsonElement getIGConfigElement(String igName, String igCode) throws BallerinaHealthException {
+
+        if (igCode != null && igCode.isEmpty()) {
+            return getIGConfigElement(igName, igCode, "");
+        } else {
+            return getIGConfigElement(igName, igName, "");
+        }
+    }
+
+    public static void throwLauncherException(Throwable error) throws BLauncherException {
         BLauncherException launcherException = new BLauncherException();
         launcherException.initCause(error);
         throw launcherException;
+    }
+
+    public static List<String> getDirectories(Path specifiedPath) {
+        List<String> subDirectories = new ArrayList<>();
+        File specPath = new File(specifiedPath.toString());
+        File[] files = specPath.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    subDirectories.add(file.getName());
+                }
+            }
+        }
+        return subDirectories;
     }
 }

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -371,7 +371,7 @@ public class FhirSubCmd implements BLauncherCmd {
         if (igName != null && !igName.isEmpty()) {
             //check if a directory exists; if so, process spec files in that directory.
             // Multiple directories are not supported.
-            if (isOverrideBlocked(subDirCount, fhirToolConfig, igName, igCode)) {
+            if (canOverrideConfig(subDirCount, fhirToolConfig, igName, igCode)) {
                 //check for spec files
                 if (Files.exists(specificationPath)) {
                     fhirToolConfig.overrideConfig("FHIRImplementationGuides", HealthCmdUtils.getIGConfigElement(
@@ -383,7 +383,7 @@ public class FhirSubCmd implements BLauncherCmd {
             }
         } else {
             //take directory name as igName and proceed. Multiple directories are not supported.
-            if (isOverrideBlocked(subDirCount, fhirToolConfig, "", "")) {
+            if (canOverrideConfig(subDirCount, fhirToolConfig, "", "")) {
                 //no ig name provided, no directories found. Can't proceed.
                 printStream.println("Can't proceed with the given path.");
                 HealthCmdUtils.exitError(this.exitWhenFinish);
@@ -392,7 +392,7 @@ public class FhirSubCmd implements BLauncherCmd {
 
     }
 
-    private boolean isOverrideBlocked(int subDirCount, FHIRToolConfig fhirToolConfig, String igName, String igCode) {
+    private boolean canOverrideConfig(int subDirCount, FHIRToolConfig fhirToolConfig, String igName, String igCode) {
         if (subDirCount > 1) {
             //not supported. Maybe we can let standard IG names to be executed.
             printStream.println("Generating packages for multiple IGs is not supported.");

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -261,6 +261,12 @@ public class FhirSubCmd implements BLauncherCmd {
                         if (packageName != null && !packageName.isEmpty()) {
                             JsonElement overrideConfig = new Gson().toJsonTree(packageName);
                             toolConfigInstance.overrideConfig("packageConfig.name", overrideConfig);
+                        } else if (igName != null && !igName.isEmpty()) {
+                            JsonElement overrideConfig = new Gson().toJsonTree(igName);
+                            toolConfigInstance.overrideConfig("packageConfig.name.append", overrideConfig);
+                        } else {
+                            JsonElement overrideConfig = new Gson().toJsonTree(HealthCmdUtils.getDirectories(specificationPath).get(0));
+                            toolConfigInstance.overrideConfig("packageConfig.name.append", overrideConfig);
                         }
                         if (orgName != null && !orgName.isEmpty()) {
                             JsonElement overrideConfig = new Gson().toJsonTree(orgName);

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -218,7 +218,7 @@ public class FhirSubCmd implements BLauncherCmd {
                 //override default configs for package-gen mode with user provided configs
                 if (igName != null && !igName.isEmpty()) {
                     fhirToolConfig.overrideConfig("FHIRImplementationGuides", HealthCmdUtils.getIGConfigElement(
-                            igName, igCode, specPathParam));
+                            igName, igCode, ""));
                 }
 
                 fhirToolConfig.setSpecBasePath(specificationPath.toString());

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -361,18 +361,11 @@ public class FhirSubCmd implements BLauncherCmd {
     private void handleSpecificationPathAndOverride(FHIRToolConfig fhirToolConfig, Path specificationPath)
             throws BallerinaHealthException {
 
+        int subDirCount = HealthCmdUtils.getDirectories(specificationPath).size();
         if (igName != null && !igName.isEmpty()) {
             //check if a directory exists; if so, process spec files in that directory.
             // Multiple directories are not supported.
-            if (HealthCmdUtils.getDirectories(specificationPath).size() > 1) {
-                //not supported. Maybe we can let if IG name is exist in default config.
-                HealthCmdUtils.exitError(this.exitWhenFinish);
-            } else if (HealthCmdUtils.getDirectories(specificationPath).size() == 1) {
-                //valid directory, look for spec files
-                String igDirPath = HealthCmdUtils.getDirectories(specificationPath).get(0);
-                fhirToolConfig.overrideConfig("FHIRImplementationGuides", HealthCmdUtils.getIGConfigElement(
-                        igName, igCode, HealthCmdUtils.generateIgDirectoryPath(specificationPath.toString(), igDirPath)));
-            } else {
+            if (isOverrideBlocked(subDirCount, fhirToolConfig, igName, igCode)) {
                 //check for spec files
                 if (Files.exists(specificationPath)) {
                     fhirToolConfig.overrideConfig("FHIRImplementationGuides", HealthCmdUtils.getIGConfigElement(
@@ -384,20 +377,33 @@ public class FhirSubCmd implements BLauncherCmd {
             }
         } else {
             //take directory name as igName and proceed. Multiple directories are not supported.
-            if (HealthCmdUtils.getDirectories(specificationPath).size() > 1) {
-                //not supported. Maybe we can let standard IG names to be executed.
-                HealthCmdUtils.exitError(this.exitWhenFinish);
-            } else if (HealthCmdUtils.getDirectories(specificationPath).size() == 1) {
-                //valid directory, look for spec files
-                String igDirPath = HealthCmdUtils.getDirectories(specificationPath).get(0);
-                fhirToolConfig.overrideConfig("FHIRImplementationGuides", HealthCmdUtils.getIGConfigElement(
-                        igDirPath, igDirPath, HealthCmdUtils.generateIgDirectoryPath(specificationPath.toString(), igDirPath)));
-            } else {
+            if (isOverrideBlocked(subDirCount, fhirToolConfig, "", "")) {
                 //no ig name provided, no directories found. Can't proceed.
                 printStream.println("Can't proceed with the given path.");
                 HealthCmdUtils.exitError(this.exitWhenFinish);
             }
         }
 
+    }
+
+    private boolean isOverrideBlocked(int subDirCount, FHIRToolConfig fhirToolConfig, String igName, String igCode) {
+        if (subDirCount > 1) {
+            //not supported. Maybe we can let standard IG names to be executed.
+            printStream.println("Generating packages for multiple IGs is not supported.");
+            HealthCmdUtils.exitError(this.exitWhenFinish);
+        } else if (subDirCount == 1) {
+            //valid directory, look for spec files
+            String igDirName = HealthCmdUtils.getDirectories(specificationPath).get(0);
+            if (igName.isEmpty()) {
+                igName = igDirName;
+            }
+            if (igCode.isEmpty()) {
+                igCode = igDirName;
+            }
+            fhirToolConfig.overrideConfig("FHIRImplementationGuides", HealthCmdUtils.getIGConfigElement(
+                    igName, igCode, HealthCmdUtils.generateIgDirectoryPath(specificationPath.toString(), igDirName)));
+            return false;
+        }
+        return true;
     }
 }

--- a/native/health-cli/src/main/resources/tool-config.json
+++ b/native/health-cli/src/main/resources/tool-config.json
@@ -154,7 +154,7 @@
           "enable": true,
           "packageConfigs": {
             "org": "ballerinax",
-            "name": "healthcare.fhir.r4.international401",
+            "name": "healthcare.fhir",
             "version": "0.0.1",
             "ballerinaDistribution": "2201.6.0",
             "authors": ["Ballerina"],
@@ -171,6 +171,7 @@
             },
             {
               "implementationGuide": "USCore",
+
               "enable": true,
               "includedProfiles": [],
               "excludedProfiles": []


### PR DESCRIPTION
## Purpose
> Remove constraint to have the same directory name as the default config for Implementation Guides. Add support to generate Ballerina packages for custom Implementation Guides.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related
> https://github.com/wso2-enterprise/open-healthcare/issues/1260

