### PR TITLE
Fix bug for cds template generation

### DIFF
--- a/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/generator/BallerinaCDSProjectGenerator.java
+++ b/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/generator/BallerinaCDSProjectGenerator.java
@@ -18,6 +18,7 @@
 
 package org.wso2.healthcare.cds.codegen.ballerina.tool.generator;
 
+import org.apache.commons.lang.StringUtils;
 import org.wso2.healthcare.cds.codegen.ballerina.tool.BallerinaCDSProjectConstants;
 import org.wso2.healthcare.cds.codegen.ballerina.tool.config.BallerinaCDSProjectToolConfig;
 import org.wso2.healthcare.cds.codegen.ballerina.tool.model.BallerinaService;
@@ -131,6 +132,6 @@ public class BallerinaCDSProjectGenerator extends AbstractFHIRTemplateGenerator 
         StringBuilder textCopy = new StringBuilder(text);
         textCopy.setCharAt(ZERO, Character.toUpperCase(firstCharOfText));
         text = textCopy.toString();
-        return text;
+        return text.replaceAll(UNDERSCORE, StringUtils.EMPTY);
     }
 }


### PR DESCRIPTION
## Purpose
> While generating handling methods for each hook backend connectivity, there is an issue with the method name.
> For instance, connectDecisionSystemForBook_Imaging_Center --> connectDecisionSystemForBookImagingCenter