### PR TITLE
Fix cardinality with array issue

### DIFF
--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/DatatypeContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/DatatypeContextGenerator.java
@@ -92,7 +92,7 @@ public class DatatypeContextGenerator {
                     Element element = new Element();
                     element.setMax(GeneratorUtils.getMaxCardinality(elementDefinition.getMax()));
                     element.setMin(elementDefinition.getMin());
-                    element.setArray(!elementDefinition.getMax().equals("0") && !elementDefinition.getMax().equals("1"));
+                    element.setArray(!elementDefinition.getBase().getMax().equals("0") && !elementDefinition.getBase().getMax().equals("1"));
                     String typeCode = elementDefinition.getType().get(0).getCode();
                     if (GeneratorUtils.getInstance().shouldReplacedByBalType(typeCode)) {
                         element.setDataType(GeneratorUtils.getInstance().resolveDataType(typeCode));

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/DatatypeContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/DatatypeContextGenerator.java
@@ -92,7 +92,7 @@ public class DatatypeContextGenerator {
                     Element element = new Element();
                     element.setMax(GeneratorUtils.getMaxCardinality(elementDefinition.getMax()));
                     element.setMin(elementDefinition.getMin());
-                    element.setArray(!elementDefinition.getBase().getMax().equals("0") && !elementDefinition.getBase().getMax().equals("1"));
+                    element.setArray(!"0".equals(elementDefinition.getBase().getMax()) && !"1".equals(elementDefinition.getBase().getMax()));
                     String typeCode = elementDefinition.getType().get(0).getCode();
                     if (GeneratorUtils.getInstance().shouldReplacedByBalType(typeCode)) {
                         element.setDataType(GeneratorUtils.getInstance().resolveDataType(typeCode));

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/ResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/ResourceContextGenerator.java
@@ -541,7 +541,7 @@ public class ResourceContextGenerator {
      * @return is an element array or not
      */
     private boolean isElementArray(ElementDefinition elementDefinition) {
-        return elementDefinition.getBase().getMax().equals("*") || Integer.parseInt(elementDefinition.getBase().getMax()) > 1;
+        return "*".equals(elementDefinition.getBase().getMax()) || Integer.parseInt(elementDefinition.getBase().getMax()) > 1;
     }
 
     /**

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/ResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/ResourceContextGenerator.java
@@ -507,7 +507,7 @@ public class ResourceContextGenerator {
                 populateResourceSliceElementsMap(childEntry.getValue());
                 if (element.isSlice()) {
                     ElementDefinition elementDefinition = this.resourceTemplateContextInstance.getSnapshotElementDefinitions().get(childEntry.getValue().getPath());
-                    if (elementDefinition != null && "*".equals(elementDefinition.getMax()) && childEntry.getValue().getMax() != Integer.MAX_VALUE) {
+                    if (elementDefinition != null && "*".equals(elementDefinition.getBase().getMax()) && childEntry.getValue().getMax() != Integer.MAX_VALUE) {
                         childEntry.getValue().setArray(true);
                     }
                 }
@@ -541,7 +541,7 @@ public class ResourceContextGenerator {
      * @return is an element array or not
      */
     private boolean isElementArray(ElementDefinition elementDefinition) {
-        return elementDefinition.getMax().equals("*") || Integer.parseInt(elementDefinition.getMax()) > 1;
+        return elementDefinition.getBase().getMax().equals("*") || Integer.parseInt(elementDefinition.getBase().getMax()) > 1;
     }
 
     /**

--- a/native/fhir-to-bal-lib/src/main/resources/templates/fhir_resource.vm
+++ b/native/fhir-to-bal-lib/src/main/resources/templates/fhir_resource.vm
@@ -80,15 +80,18 @@ public type $util.resolveSpecialCharacters($resourceName) record {|
 
 #foreach($element in $resourceElements)
 #set($min = 1)
-#set($max = $INT_MAX)
-#if( ($element.min >= $min ) && ($element.max == $max) )
+#set($max = 1)
+#set($separator = ",")
+## Here we should add constraint:Array only for the Array elements and min or max is 1
+#if( $element.isArray() && ($element.getMin() == $min || $element.getMax() == $max) )
     @constraint:Array {
-       minLength: $element.getMin()
-    }
-#elseif( ($element.min >= $min ) && ($element.max > 1) )
-    @constraint:Array {
-       minLength: $element.getMin(),
-       maxLength: $element.getMax()
+#if( $element.getMin() == $min )
+        minLength: $min#if( $element.getMax() == $max )$separator#end
+#end
+
+#if( $element.getMax() == $max )
+        maxLength: $max
+#end
     }
 #end
     #foreach($profileEntry in $element.getProfiles().entrySet())#if(!$dataTypes.contains($profileEntry.value.getProfileType()))#if(!$profileEntry.value.getPrefix())${importIdentifier}#else$profileEntry.value.getPrefix():#end#end$util.resolveSpecialCharacters($profileEntry.value.getProfileType())#if($element.isArray())[]#end#if($velocityCount != $element.getProfiles().size())|#end#end $util.resolveKeywordConflict($util.resolveSpecialCharacters($element.getName()))#if(!$element.isRequired())?#end;
@@ -146,15 +149,18 @@ public type $util.resolveSpecialCharacters($extendedElement.getTypeName()) recor
 
 #foreach($childElement in $extendedElement.getElements())
 #set($min = 1)
-#set($max = $INT_MAX)
-#if( ($childElement.getMin() >= $min ) && ($childElement.getMax() == $max) )
+#set($max = 1)
+#set($separator = ",")
+## Here we should add constraint:Array only for the Array elements and min or max is 1
+#if( $childElement.isArray() && ($childElement.getMin() == $min || $childElement.getMax() == $max) )
     @constraint:Array {
-       minLength: $childElement.getMin()
-    }
-#elseif( $childElement.isArray() && ($childElement.min >= $min ) && ($childElement.max >= 1) )
-    @constraint:Array {
-       minLength: $childElement.getMin(),
-       maxLength: $childElement.getMax()
+#if( $childElement.getMin() == $min )
+        minLength: $min#if( $childElement.getMax() == $max )$separator#end
+#end
+
+#if( $childElement.getMax() == $max )
+        maxLength: $max
+#end
     }
 #end
 #if($childElement.hasFixedValue())


### PR DESCRIPTION
## Purpose
> Issue: https://github.com/wso2-enterprise/open-healthcare/issues/1663#event-15376173000

## Approach
>  In the previous implementation, we used the child profile's cardinality information to decide whether the particular element is an array. But we should refer to the base resource's cardinality instead.
> While implementing, we only considered the four different cardinalities mentioned in the [specification](https://build.fhir.org/conformance-rules.html#:~:text=0..1%2C%200..*%2C%201..1%2C%20and%201..*).