### PR TITLE
[Ballerina Health Tool] Add Codes to Consider Content Reference Elements

### DIFF
--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/ToolConstants.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/ToolConstants.java
@@ -44,6 +44,7 @@ public class ToolConstants {
     public static final String CONFIG_VERSION_CONFIGS = "versionConfigs";
     public static final String CONFIG_PACKAGE_REPOSITORY = "repository";
     public static final String CONFIG_BASE_PACKAGE = "basePackage";
+    public static final String CONFIG_INTERNATIONAL_PACKAGE = "internationalPackage";
 
     ///  to-do: check the breakability of elements like above when initiating the tool from
     /// a tool-config.toml file
@@ -51,6 +52,8 @@ public class ToolConstants {
     public static final String CONFIG_R5_PACKAGE_REPOSITORY_TOML = "tools.config.package.version_configs.r5.repository";
     public static final String CONFIG_R4_BASE_PACKAGE_TOML = "tools.config.package.base_package";
     public static final String CONFIG_R5_BASE_PACKAGE_TOML = "tools.config.package.version_configs.r5.base_package";
+    public static final String CONFIG_R4_INTERNATIONAL_PACKAGE_TOML = "tools.config.package.version_configs.r4.international_package";
+    public static final String CONFIG_R5_INTERNATIONAL_PACKAGE_TOML = "tools.config.package.version_configs.r5.international_package";
 
     public static final String CONFIG_PACKAGE_DEPENDENCY = "dependencies";
     public static final String CONFIG_PACKAGE_DEPENDENCY_TOML = "tools.config.package.dependency";

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/config/BallerinaPackageGenToolConfig.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/config/BallerinaPackageGenToolConfig.java
@@ -122,6 +122,9 @@ public class BallerinaPackageGenToolConfig extends AbstractToolConfig {
             case "packageConfig.basePackage":
                 this.packageConfig.setBasePackage(value.getAsString());
                 break;
+            case "packageConfig.internationalPackage":
+                this.packageConfig.setInternationalPackage(value.getAsString());
+                break;
             case "packageConfig.dependent.igs":
                 List<String> dependentIgList = new ArrayList<>();
                 for (JsonElement dependentIgJsonElement : value.getAsJsonArray()) {

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/config/PackageConfig.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/config/PackageConfig.java
@@ -45,6 +45,7 @@ public class PackageConfig {
     private String fhirVersion;
     private String repository;
     private String basePackage;
+    private String internationalPackage;
     private List<DependencyConfig> dependencyConfigList;
     private final Map<String, String> dependentIgs = new HashMap<>();
 
@@ -66,6 +67,11 @@ public class PackageConfig {
                 getAsJsonObject(this.fhirVersion).
                 getAsJsonPrimitive(ToolConstants.CONFIG_BASE_PACKAGE).getAsString();
 
+        this.internationalPackage = packageConfigJson.
+                getAsJsonObject(ToolConstants.CONFIG_VERSION_CONFIGS).
+                getAsJsonObject(this.fhirVersion).
+                getAsJsonPrimitive(ToolConstants.CONFIG_INTERNATIONAL_PACKAGE).getAsString();
+
         populateDependencies(packageConfigJson.getAsJsonArray(ToolConstants.CONFIG_PACKAGE_DEPENDENCY).getAsJsonArray());
     }
 
@@ -82,9 +88,11 @@ public class PackageConfig {
         if (this.fhirVersion.equalsIgnoreCase("r4")) {
             this.repository = packageConfigToml.getString(ToolConstants.CONFIG_R4_PACKAGE_REPOSITORY_TOML);
             this.basePackage = packageConfigToml.getString(ToolConstants.CONFIG_R4_BASE_PACKAGE_TOML);
+            this.internationalPackage = packageConfigToml.getString(ToolConstants.CONFIG_R4_INTERNATIONAL_PACKAGE_TOML);
         } else if (this.fhirVersion.equalsIgnoreCase("r5")) {
             this.repository = packageConfigToml.getString(ToolConstants.CONFIG_R5_PACKAGE_REPOSITORY_TOML);
             this.basePackage = packageConfigToml.getString(ToolConstants.CONFIG_R5_BASE_PACKAGE_TOML);
+            this.internationalPackage = packageConfigToml.getString(ToolConstants.CONFIG_R5_INTERNATIONAL_PACKAGE_TOML);
         }
 
         populateDependencies(packageConfigToml.getArrayOrEmpty(ToolConstants.CONFIG_PACKAGE_DEPENDENCY_TOML));
@@ -139,6 +147,10 @@ public class PackageConfig {
         return basePackage;
     }
 
+    public String getInternationalPackage() {
+        return internationalPackage;
+    }
+
     public List<DependencyConfig> getDependencyConfigList() {
         return dependencyConfigList;
     }
@@ -180,6 +192,10 @@ public class PackageConfig {
 
     public void setBasePackage(String basePackage) {
         this.basePackage = basePackage;
+    }
+
+    public void setInternationalPackage(String internationalPackage) {
+        this.internationalPackage = internationalPackage;
     }
 
     public void setAuthors(String authors) {

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/AnnotationElement.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/AnnotationElement.java
@@ -34,6 +34,7 @@ public class AnnotationElement {
     private String valueSet;
     private boolean mustSupport;
     private boolean isExtended;
+    private String contentReference;
 
     public String getName() {
         return name;
@@ -120,5 +121,13 @@ public class AnnotationElement {
 
     public void setExtended(boolean extended) {
         isExtended = extended;
+    }
+
+    public String getContentReference() {
+        return contentReference;
+    }
+
+    public void setContentReference(String contentReference) {
+        this.contentReference = contentReference;
     }
 }

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/DataTypeProfile.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/DataTypeProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/Element.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/Element.java
@@ -45,6 +45,9 @@ public class Element {
     private String summary;
     private String requirement;
 
+    // Saves the content reference element is available.
+    private String contentReference;
+
     public String getDataType() {
         return dataType;
     }
@@ -200,4 +203,11 @@ public class Element {
         this.requirement = requirement;
     }
 
+    public void setContentReference(String contentReference) {
+        this.contentReference = contentReference;
+    }
+
+    public String getContentReference() {
+        return contentReference;
+    }
 }

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/Element.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/Element.java
@@ -55,6 +55,7 @@ public class Element {
     public void setDataType(String dataType) {
         this.dataType = dataType;
     }
+
     public Map<String, DataTypeProfile> getProfiles() {
         return profiles;
     }

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/PackageTemplateContext.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/PackageTemplateContext.java
@@ -28,6 +28,7 @@ import java.util.Set;
 public class PackageTemplateContext {
     private IGTemplateContext igTemplateContext;
     private String basePackageName;
+    private String internationalPackageName;
     private Map<String, ResourceTemplateContext> resourceTemplateContextMap;
     private Map<String, DatatypeTemplateContext> datatypeTemplateContextMap;
     private Map<String, String> resourceNameTypeMap;
@@ -49,6 +50,14 @@ public class PackageTemplateContext {
 
     public void setBasePackageName(String basePackageName) {
         this.basePackageName = basePackageName;
+    }
+
+    public String getInternationalPackageName() {
+        return internationalPackageName;
+    }
+
+    public void setInternationalPackageName(String internationalPackageName) {
+        this.internationalPackageName = internationalPackageName;
     }
 
     public Map<String, ResourceTemplateContext> getResourceTemplateContextMap() {

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/AbstractPackageContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/AbstractPackageContextGenerator.java
@@ -65,6 +65,10 @@ public abstract class AbstractPackageContextGenerator {
                 this.packageContext.setBasePackageName(toolConfig.getPackageConfig().getBasePackage());
             }
 
+            if (toolConfig.getPackageConfig().getInternationalPackage() != null) {
+                this.packageContext.setInternationalPackageName(toolConfig.getPackageConfig().getInternationalPackage());
+            }
+
             Map<String, String> dependencyMap = new HashMap<>();
             for (DependencyConfig dependencyConfig : toolConfig.getPackageConfig().getDependencyConfigList()) {
                 dependencyMap.put(dependencyConfig.getName(), dependencyConfig.getOrg() + "/" + dependencyConfig.getName());

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/AbstractResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/AbstractResourceContextGenerator.java
@@ -110,11 +110,11 @@ public abstract class AbstractResourceContextGenerator {
      *
      * @param element The element to check for international imports.
      */
-    protected void checkAndAddInternationalImport(Element element){
+    protected void checkAndAddInternationalImport(Element element) {
         boolean isImportedFromInternational = false;
-        if (element.getContentReference() != null && GeneratorUtils.isReferredFromInternational(element.getContentReference())){
+        if (element.getContentReference() != null && GeneratorUtils.isReferredFromInternational(element.getContentReference())) {
             isImportedFromInternational = true;
-        } else if (element.hasChildElements()){
+        } else if (element.hasChildElements()) {
             for (Element childElement : element.getChildElements().values()) {
                 if (childElement.getContentReference() != null && GeneratorUtils.isReferredFromInternational(childElement.getContentReference())) {
                     isImportedFromInternational = true;
@@ -126,7 +126,7 @@ public abstract class AbstractResourceContextGenerator {
                 .stream()
                 .anyMatch(d -> d.equals(this.toolConfig.getPackageConfig().getInternationalPackage()));
 
-        if(isImportedFromInternational && !isInternationalImportExists){
+        if (isImportedFromInternational && !isInternationalImportExists) {
             this.resourceTemplateContextInstance.getResourceDependencies().add(this.toolConfig.getPackageConfig().getInternationalPackage());
         }
     }
@@ -190,7 +190,7 @@ public abstract class AbstractResourceContextGenerator {
 
             // Only creates annotation if the element does not have a content reference.
             // Because the type of referred elements is set to BackboneElement temporarily.
-            if(element.getContentReference() == null){
+            if (element.getContentReference() == null) {
                 DataTypeDefinitionAnnotation annotation = new DataTypeDefinitionAnnotation();
                 annotation.setName(extendedElement.getTypeName());
 

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/templategen/ResourceTemplateGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/templategen/ResourceTemplateGenerator.java
@@ -72,6 +72,15 @@ public class ResourceTemplateGenerator extends AbstractFHIRTemplateGenerator {
             this.resourceProperties.put("importIdentifier", basePackageIdentifier + ":");
         }
 
+        if (this.packageTemplateContext.getInternationalPackageName() != null) {
+            this.resourceProperties.put("isInternationalPackage", false);
+            String internationalPackage = this.packageTemplateContext.getInternationalPackageName();
+            String internationalPackageIdentifier = internationalPackage.substring(internationalPackage.lastIndexOf(".") + 1);
+            this.resourceProperties.put("internationalPackage", internationalPackage);
+            this.resourceProperties.put("internationalPackageIdentifier", internationalPackageIdentifier);
+            this.resourceProperties.put("internationalImportIdentifier", internationalPackageIdentifier + ":");
+        }
+
         this.resourceTemplateContexts = new ArrayList<>(this.packageTemplateContext.getResourceTemplateContextMap().values());
         generateFHIRResources();
         LOG.debug("Ended: Resource Templates Generation");
@@ -131,6 +140,10 @@ public class ResourceTemplateGenerator extends AbstractFHIRTemplateGenerator {
         templateContext.setProperty("isBasePackage", this.resourceProperties.get("isBasePackage"));
         templateContext.setProperty("basePackageIdentifier", this.resourceProperties.get("basePackageIdentifier"));
         templateContext.setProperty("importIdentifier", this.resourceProperties.get("importIdentifier"));
+
+        templateContext.setProperty("isInternationalPackage", this.resourceProperties.get("isInternationalPackage"));
+        templateContext.setProperty("internationalPackageIdentifier", this.resourceProperties.get("internationalPackageIdentifier"));
+        templateContext.setProperty("internationalImportIdentifier", this.resourceProperties.get("internationalImportIdentifier"));
 
         Set<String> resourceDependencies = new TreeSet<>();
         if (!(boolean) this.resourceProperties.get("isBasePackage")) {

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/templategen/ResourceTemplateGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/templategen/ResourceTemplateGenerator.java
@@ -105,8 +105,8 @@ public class ResourceTemplateGenerator extends AbstractFHIRTemplateGenerator {
                         + ToolConstants.BAL_EXTENSION, "");
 
                 this.getTemplateEngine().generateOutputAsFile(ToolConstants.TEMPLATE_PATH +
-                                ToolConstants.RESOURCE_PATH_SEPERATOR + "fhir_resource.vm", this.createTemplateContextForResourceSkeletons(
-                                        resourceTemplateContext, this.packageTemplateContext), "", filePath);
+                        ToolConstants.RESOURCE_PATH_SEPERATOR + "fhir_resource.vm", this.createTemplateContextForResourceSkeletons(
+                        resourceTemplateContext, this.packageTemplateContext), "", filePath);
             }
         } catch (CodeGenException e) {
             throw new CodeGenException("Error occurred while generating template artifacts for fhir resource", e);

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/GeneratorUtils.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/GeneratorUtils.java
@@ -342,10 +342,9 @@ public class GeneratorUtils {
         if (element.getChildElements() != null) {
             extendedElement.setElements(element.getChildElements());
         }
-        if (!GeneratorUtils.isPrimitiveElement(baseType)){
+        if (!GeneratorUtils.isPrimitiveElement(baseType)) {
             extendedElement.setBaseType(baseType);
-        }
-        else if (GeneratorUtils.isPrimitiveElement(baseType) && !baseType.equals("code")){
+        } else if (GeneratorUtils.isPrimitiveElement(baseType) && !baseType.equals("code")) {
             // Handle the rare case of extended elements with primitive base types
             // FHIR R5: Patient.birthDate, Patient.birthDate.id, Patient.birthDate.value etc.
             // where Patient.birthDate = r5: date
@@ -471,7 +470,7 @@ public class GeneratorUtils {
             ///  place should be investigated.
             String assigningType = VALUESET_DATA_TYPES.get(baseType).get(fieldName);
 
-            if(!assigningType.equalsIgnoreCase(assignedType)){
+            if (!assigningType.equalsIgnoreCase(assignedType)) {
                 return assignedType;
             }
             return VALUESET_DATA_TYPES.get(baseType).get(fieldName);
@@ -515,8 +514,8 @@ public class GeneratorUtils {
     /**
      * Populates available code values for a given code element.
      *
-     * @param shortField        short text from the element definition of FHIR specification
-     * @param element           element model for template context
+     * @param shortField short text from the element definition of FHIR specification
+     * @param element    element model for template context
      */
     public static void populateCodeValuesForCodeElements(String shortField, Element element) {
         if (!shortField.contains("|")) {
@@ -540,13 +539,14 @@ public class GeneratorUtils {
 
     /**
      * Check if an element is referred from an international specification.
+     *
      * @param contentReference The contentReference field of an Element.
-     * NOTE: These elements do not have a TypeRefComponent
-     * */
+     *                         NOTE: These elements do not have a TypeRefComponent
+     */
     public static boolean isReferredFromInternational(String contentReference) {
         // Refers a resource from international specification
         // e.g.: http://hl7.org/fhir/StructureDefinition/Parameters#Parameters.parameter
-        if (contentReference != null){
+        if (contentReference != null) {
             return contentReference.startsWith("http://hl7.org/fhir/StructureDefinition/");
         }
         return false;
@@ -556,16 +556,16 @@ public class GeneratorUtils {
      * Get the referring element name from the content reference.
      * This method handles both international and local references.
      *
-     * @param contentReference The content reference string.
+     * @param contentReference            The content reference string.
      * @param isReferredFromInternational Whether the reference is from an international specification.
-     * @param typeNamePrefix The prefix to be added to the referring element name.
+     * @param typeNamePrefix              The prefix to be added to the referring element name.
      * @return The formatted referring element name.
      */
     public static String getReferringElementName(String contentReference, boolean isReferredFromInternational, String typeNamePrefix) {
         String referringElementName = contentReference.split("#")[1];
-        String [] subElements = referringElementName.split("\\.");
+        String[] subElements = referringElementName.split("\\.");
 
-        if(isReferredFromInternational){
+        if (isReferredFromInternational) {
             // If the content reference is from international --> remove the prefix
             // e.g.: http://hl7.org/fhir/StructureDefinition/Parameters#Parameters.parameter --> international401:Parameters.parameter
             // Assumes that international resources don't have special characters (e.g.: ':') in the URL
@@ -576,7 +576,7 @@ public class GeneratorUtils {
             }
             referringElementName = newElementName.toString();
         } else {
-            if (referringElementName.contains(":") || StringUtils.countMatches(referringElementName, ".") > 1){
+            if (referringElementName.contains(":") || StringUtils.countMatches(referringElementName, ".") > 1) {
                 // If the content reference is like #Provenance.agent:ProvenanceTransmitter --> USCoreProvenanceAgentProvenanceTransmitter
                 // or #ExplanationOfBenefit.item.reviewOutcome --> ExplanationOfBenefitItemReviewOutcome
                 // referred by the Element with path ExplanationOfBenefit.addItem.detail.subDetail.reviewOutcome
@@ -587,7 +587,7 @@ public class GeneratorUtils {
                     newElementName.append(CommonUtil.toCamelCase(subElement));
                 }
                 referringElementName = newElementName.toString();
-                if(referringElementName.startsWith(subElements[0])){
+                if (referringElementName.startsWith(subElements[0])) {
                     referringElementName = referringElementName.substring(subElements[0].length());
                 }
                 referringElementName = typeNamePrefix + referringElementName;

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/GeneratorUtils.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/GeneratorUtils.java
@@ -307,6 +307,7 @@ public class GeneratorUtils {
         annotationElement.setPath(element.getPath());
         annotationElement.setValueSet(element.getValueSet());
         annotationElement.setExtended(element.isExtended());
+        annotationElement.setContentReference(element.getContentReference());
         LOG.debug("Ended: Annotation Element population");
         return annotationElement;
     }
@@ -322,7 +323,15 @@ public class GeneratorUtils {
                                                    String typeNamePrefix) {
         LOG.debug("Started: Resource Extended Element population");
         ExtendedElement extendedElement = new ExtendedElement();
-        String extendedElementTypeName = generateExtendedElementIdentifier(element, typeNamePrefix);
+        String extendedElementTypeName;
+
+        if (element.getContentReference() != null && !isReferredFromInternational(element.getContentReference())) {
+            // Avoid creation of a new identifiers for referred elements
+            extendedElementTypeName = getReferringElementName(element.getContentReference(), false, typeNamePrefix);
+        } else {
+            extendedElementTypeName = generateExtendedElementIdentifier(element, typeNamePrefix);
+        }
+
         extendedElement.setTypeName(extendedElementTypeName);
         if (element.getProfiles() != null && element.getProfiles().containsKey(element.getDataType())) {
             element.getProfiles().get(element.getDataType()).setProfileType(extendedElement.getTypeName());
@@ -527,5 +536,71 @@ public class GeneratorUtils {
             }
         }
         element.setChildElements(childElements);
+    }
+
+    /**
+     * Check if an element is referred from an international specification.
+     * @param contentReference The contentReference field of an Element.
+     * NOTE: These elements do not have a TypeRefComponent
+     * */
+    public static boolean isReferredFromInternational(String contentReference) {
+        // Refers a resource from international specification
+        // e.g.: http://hl7.org/fhir/StructureDefinition/Parameters#Parameters.parameter
+        if (contentReference != null){
+            return contentReference.startsWith("http://hl7.org/fhir/StructureDefinition/");
+        }
+        return false;
+    }
+
+    /**
+     * Get the referring element name from the content reference.
+     * This method handles both international and local references.
+     *
+     * @param contentReference The content reference string.
+     * @param isReferredFromInternational Whether the reference is from an international specification.
+     * @param typeNamePrefix The prefix to be added to the referring element name.
+     * @return The formatted referring element name.
+     */
+    public static String getReferringElementName(String contentReference, boolean isReferredFromInternational, String typeNamePrefix) {
+        String referringElementName = contentReference.split("#")[1];
+        String [] subElements = referringElementName.split("\\.");
+
+        if(isReferredFromInternational){
+            // If the content reference is from international --> remove the prefix
+            // e.g.: http://hl7.org/fhir/StructureDefinition/Parameters#Parameters.parameter --> international401:Parameters.parameter
+            // Assumes that international resources don't have special characters (e.g.: ':') in the URL
+
+            StringBuilder newElementName = new StringBuilder();
+            for (String subElement : subElements) {
+                newElementName.append(CommonUtil.toCamelCase(subElement));
+            }
+            referringElementName = newElementName.toString();
+        } else {
+            if (referringElementName.contains(":") || StringUtils.countMatches(referringElementName, ".") > 1){
+                // If the content reference is like #Provenance.agent:ProvenanceTransmitter --> USCoreProvenanceAgentProvenanceTransmitter
+                // or #ExplanationOfBenefit.item.reviewOutcome --> ExplanationOfBenefitItemReviewOutcome
+                // referred by the Element with path ExplanationOfBenefit.addItem.detail.subDetail.reviewOutcome
+
+                subElements = referringElementName.split("[.:]");
+                StringBuilder newElementName = new StringBuilder();
+                for (String subElement : subElements) {
+                    newElementName.append(CommonUtil.toCamelCase(subElement));
+                }
+                referringElementName = newElementName.toString();
+                if(referringElementName.startsWith(subElements[0])){
+                    referringElementName = referringElementName.substring(subElements[0].length());
+                }
+                referringElementName = typeNamePrefix + referringElementName;
+            } else {
+                // If the content reference is a local reference with same path used in multiple resources
+                // Observation.referenceRange --> USCorePediatricBMIforAgeObservationProfileReferenceRange or
+                // Observation.referenceRange --> USCorePediatricWeightForHeightObservationProfileReferenceRange or
+                // Observation.referenceRange --> USCoreSmokingStatusProfileReferenceRange etc.
+
+                referringElementName = CommonUtil.toCamelCase(subElements[subElements.length - 1]);
+                referringElementName = typeNamePrefix + referringElementName;
+            }
+        }
+        return referringElementName;
     }
 }

--- a/native/fhir-to-bal-lib/src/main/resources/templates/fhir_resource.vm
+++ b/native/fhir-to-bal-lib/src/main/resources/templates/fhir_resource.vm
@@ -57,7 +57,7 @@ public const RESOURCE_NAME_${util.resolveSpecialCharacters($resourceName.toUpper
     #foreach($element in ${annotationElements})
         "${element.getName()}" : {
             name: "${element.getName()}",
-            dataType: #if(!$dataTypes.contains($element.getDataType()))${importIdentifier}$util.resolveSpecialCharacters($element.getDataType())#else$util.resolveSpecialCharacters($element.getDataType())#end,
+            dataType: #if(!$dataTypes.contains($element.getDataType()))#if($util.isReferredFromInternational($element.getContentReference()))${internationalImportIdentifier}$element.getDataType()#else${importIdentifier}$util.resolveSpecialCharacters($element.getDataType())#end#else$util.resolveSpecialCharacters($element.getDataType())#end,
             min: ${element.getMin()},
             max: ${element.getMax()},
             isArray: ${element.isArray()},
@@ -94,10 +94,9 @@ public type $util.resolveSpecialCharacters($resourceName) record {|
         minLength: {
             value: $min$separator
             message: "Validation failed for $.$element.getPath() constraint. This field must be an array containing at least one item."
-        }#if( $element.getMax() > 0 )$separator#end
+        }#if( $element.getMax() > 0 && $element.getMax() != $INT_MAX)$separator#end
         #end
-
-        #if( $element.getMax() > 0 )
+        #if( $element.getMax() > 0 && $element.getMax() != $INT_MAX)
         maxLength: {
             value: $max$separator
             message: "Validation failed for $.$element.getPath() constraint. This field must be an array containing at most one item."
@@ -106,7 +105,7 @@ public type $util.resolveSpecialCharacters($resourceName) record {|
     }
 $tab#end
     #set($isDataTypeSet = false)
-    #foreach($profileEntry in $element.getProfiles().entrySet())#if(!$dataTypes.contains($profileEntry.value.getProfileType()))#if(!$profileEntry.value.getPrefix())${importIdentifier}#else$profileEntry.value.getPrefix():#end#end#if($element.isExtended())#foreach($key in $extendedElements.keySet())#if($key == $profileEntry.value.getProfileType() && $extendedElements.get($key).getPrimitiveExtendedType())$util.resolveSpecialCharacters($profileEntry.value.getProfileType()) | ${importIdentifier}$extendedElements.get($key).getPrimitiveExtendedType()#set($isDataTypeSet = true)#end#end#end#if(!$isDataTypeSet)$util.resolveSpecialCharacters($profileEntry.value.getProfileType())#end#if($element.isArray()) []#end#if($foreach.count != $element.getProfiles().size())|#end#end $util.resolveKeywordConflict($util.resolveSpecialCharacters($element.getName()))#if(!$element.isRequired())?#end;
+        #foreach($profileEntry in $element.getProfiles().entrySet())#if(!$dataTypes.contains($profileEntry.value.getProfileType()))#if(!$profileEntry.value.getPrefix())#if($util.isReferredFromInternational($element.getContentReference()))${internationalImportIdentifier}#else${importIdentifier}#end#else$profileEntry.value.getPrefix():#end#end#if($element.isExtended())#foreach($key in $extendedElements.keySet())#if($key == $profileEntry.value.getProfileType() && $extendedElements.get($key).getPrimitiveExtendedType())$util.resolveSpecialCharacters($profileEntry.value.getProfileType()) | ${importIdentifier}$extendedElements.get($key).getPrimitiveExtendedType()#set($isDataTypeSet = true)#end#end#end#if(!$isDataTypeSet)$util.resolveSpecialCharacters($profileEntry.value.getProfileType())#end#if($element.isArray()) []#end#if($foreach.count != $element.getProfiles().size())|#end#end $util.resolveKeywordConflict($util.resolveSpecialCharacters($element.getName()))#if(!$element.isRequired())?#end;
     #end
     ${importIdentifier}Element ...;
 |};
@@ -135,7 +134,7 @@ $tab#end
         #foreach($annotationElement in $extendedElement.getAnnotation().getElements())
         "${annotationElement.getName()}": {
             name: "${annotationElement.getName()}",
-            dataType: #if(!$dataTypes.contains($annotationElement.getDataType()))${importIdentifier}$util.resolveSpecialCharacters($annotationElement.getDataType())#else$util.resolveSpecialCharacters($annotationElement.getDataType())#end,
+            dataType: #if(!$dataTypes.contains($annotationElement.getDataType()))#if($util.isReferredFromInternational($annotationElement.getContentReference()))${internationalImportIdentifier}$annotationElement.getDataType()#else${importIdentifier}$util.resolveSpecialCharacters($annotationElement.getDataType())#end#else$util.resolveSpecialCharacters($annotationElement.getDataType())#end,
             min: $annotationElement.getMin(),
             max: $annotationElement.getMax(),
             isArray: $annotationElement.isArray(),
@@ -173,10 +172,9 @@ public type $util.resolveSpecialCharacters($extendedElement.getTypeName()) recor
         minLength: {
             value: $min$separator
             message: "Validation failed for $.$childElement.getPath() constraint. This field must be an array containing at least one item."
-        }#if( $childElement.getMax() > 0 )$separator#end
+        }#if( $childElement.getMax() > 0 && $element.getMax() != $INT_MAX)$separator#end
         #end
-
-        #if( $childElement.getMax() > 0)
+        #if( $childElement.getMax() > 0 && $element.getMax() != $INT_MAX)
         maxLength: {
             value: $max$separator
             message: "Validation failed for $.$childElement.getPath() constraint. This field must be an array containing at most one item."
@@ -185,9 +183,9 @@ public type $util.resolveSpecialCharacters($extendedElement.getTypeName()) recor
     }
 $tab#end
     #if($childElement.hasFixedValue())
-        #if(!$dataTypes.contains($childElement.getDataType()))${importIdentifier}#end$util.resolveSpecialCharacters($childElement.getDataType())#if($childElement.isArray()) []#end $util.resolveSpecialCharacters($util.resolveKeywordConflict($childElement.getName()))#if(!$childElement.isRequired())?#end = #if($childElement.isArray()) [#end#foreach($value in $childElement.getFixedValue())$util.getTypedValue($value, $childElement.getDataType())#if($foreach.count != $childElement.getFixedValue().size()),#end#end#if($childElement.isArray())]#end;
+        #if(!$dataTypes.contains($childElement.getDataType()))#if($util.isReferredFromInternational($childElement.getContentReference()))${internationalImportIdentifier}#else${importIdentifier}#end#end$util.resolveSpecialCharacters($childElement.getDataType())#if($childElement.isArray()) []#end $util.resolveSpecialCharacters($util.resolveKeywordConflict($childElement.getName()))#if(!$childElement.isRequired())?#end = #if($childElement.isArray()) [#end#foreach($value in $childElement.getFixedValue())$util.getTypedValue($value, $childElement.getDataType())#if($foreach.count != $childElement.getFixedValue().size()),#end#end#if($childElement.isArray())]#end;
     #else
-        #if(!$dataTypes.contains($childElement.getDataType()))${importIdentifier}#end$util.resolveSpecialCharacters($childElement.getDataType())#if($childElement.isArray()) []#end $util.resolveSpecialCharacters($util.resolveKeywordConflict($childElement.getName()))#if(!$childElement.isRequired())?#end;
+        #if(!$dataTypes.contains($childElement.getDataType()))#if($util.isReferredFromInternational($childElement.getContentReference()))${internationalImportIdentifier}#else${importIdentifier}#end#end$util.resolveSpecialCharacters($childElement.getDataType())#if($childElement.isArray()) []#end $util.resolveSpecialCharacters($util.resolveKeywordConflict($childElement.getName()))#if(!$childElement.isRequired())?#end;
     #end
 #end
 |};

--- a/native/fhir-to-bal-lib/src/test/resources/ballerina.tests/r4/test_content_reference.bal
+++ b/native/fhir-to-bal-lib/src/test/resources/ballerina.tests/r4/test_content_reference.bal
@@ -1,0 +1,321 @@
+import ballerina/test;
+import ballerinax/health.fhir.r4.international401;
+import ballerinax/health.fhir.r4.parser;
+
+@test:Config {}
+function testReferredFromInternational() returns error? {
+    json internationalObservationInput = {
+        "resourceType": "Observation",
+        "id": "satO2",
+        "meta": {
+            "profile": ["http://hl7.org/fhir/StructureDefinition/vitalsigns"]
+        },
+        "text": {
+            "status": "generated",
+            "div": "<div></div>"
+        },
+        "identifier": [
+            {
+                "system": "http://goodcare.org/observation/id",
+                "value": "o1223435-10"
+            }
+        ],
+        "partOf": [
+            {
+                "reference": "Procedure/ob"
+            }
+        ],
+        "status": "final",
+        "code": {
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "2708-6",
+                    "display": "Oxygen saturation in Arterial blood"
+                },
+                {
+                    "system": "http://loinc.org",
+                    "code": "59408-5",
+                    "display": "Oxygen saturation in Arterial blood by Pulse oximetry"
+                },
+                {
+                    "system": "urn:iso:std:iso:11073:10101",
+                    "code": "150456",
+                    "display": "MDC_PULS_OXIM_SAT_O2"
+                }
+            ]
+        },
+        "subject": {
+            "reference": "Patient/example"
+        },
+        "effectiveDateTime": "2014-12-05T09:30:10+01:00",
+        "valueQuantity": {
+            "value": 95,
+            "unit": "%",
+            "system": "http://unitsofmeasure.org",
+            "code": "%"
+        },
+        "device": {
+            "reference": "DeviceMetric/example"
+        },
+        "referenceRange": [
+            {
+                "low": {
+                    "value": 90,
+                    "unit": "%",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "%"
+                },
+                "high": {
+                    "value": 99,
+                    "unit": "%",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "%"
+                }
+            }
+        ]
+    };
+
+    json pulseOximetryProfileInput = {
+        "resourceType": "Observation",
+        "id": "satO2-fiO2",
+        "meta": {
+            "profile": [
+                "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry|8.0.0"
+            ]
+        },
+        "text": {
+            "status": "generated",
+            "div": "<div></div>"
+        },
+        "identifier": [
+            {
+                "system": "http://example.org/FHIR/observation/identifiers",
+                "value": "o1223435-10"
+            }
+        ],
+        "status": "final",
+        "category": [
+            {
+                "coding": [
+                    {
+                        "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                        "code": "vital-signs",
+                        "display": "Vital Signs"
+                    }
+                ],
+                "text": "Vital Signs"
+            }
+        ],
+        "code": {
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "2708-6",
+                    "display": "Oxygen saturation in Arterial blood"
+                },
+                {
+                    "system": "http://loinc.org",
+                    "code": "59408-5",
+                    "display": "Oxygen saturation in Arterial blood by Pulse oximetry"
+                },
+                {
+                    "system": "urn:iso:std:iso:11073:10101",
+                    "code": "150456",
+                    "display": "MDC_PULS_OXIM_SAT_O2"
+                }
+            ]
+        },
+        "subject": {
+            "reference": "Patient/example"
+        },
+        "effectiveDateTime": "2014-12-05T09:30:10+01:00",
+        "valueQuantity": {
+            "value": 95,
+            "unit": "%",
+            "system": "http://unitsofmeasure.org",
+            "code": "%"
+        },
+        "interpretation": [
+            {
+                "coding": [
+                    {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                        "code": "N",
+                        "display": "Normal"
+                    }
+                ],
+                "text": "Normal"
+            }
+        ],
+        "device": {
+            "display": "Acme Pulse Oximeter 2000"
+        },
+        "referenceRange": [
+            {
+                "low": {
+                    "value": 90,
+                    "unit": "%",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "%"
+                },
+                "high": {
+                    "value": 99,
+                    "unit": "%",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "%"
+                }
+            }
+        ],
+        "component": [
+            {
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "3151-8",
+                            "display": "Inhaled oxygen flow rate"
+                        }
+                    ],
+                    "text": "Inhaled oxygen flow rate"
+                },
+                "valueQuantity": {
+                    "value": 6,
+                    "unit": "liters/min",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "L/min"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 90,
+                            "unit": "%",
+                            "system": "http://unitsofmeasure.org",
+                            "code": "%"
+                        },
+                        "high": {
+                            "value": 99,
+                            "unit": "%",
+                            "system": "http://unitsofmeasure.org",
+                            "code": "%"
+                        }
+                    }
+                ]
+            }
+        ]
+    };
+
+    international401:Observation international401Observation = check parser:parse(internationalObservationInput, international401:Observation).ensureType();
+    international401:ObservationReferenceRange[]? observationReferenceRange = international401Observation.referenceRange;
+
+    USCorePulseOximetryProfile usCorePulseOximetryProfile = check parser:parse(pulseOximetryProfileInput, USCorePulseOximetryProfile).ensureType();
+    USCorePulseOximetryProfileComponent[]? components = usCorePulseOximetryProfile.component;
+
+    if components is USCorePulseOximetryProfileComponent[] {
+        USCorePulseOximetryProfileComponent component = components[0];
+        test:assertEquals(component.referenceRange, observationReferenceRange, "Reference ranges in component are not equal");
+    }
+}
+
+@test:Config {}
+function testReferredFromLocal() returns error? {
+    json inputProvenance = {
+        "resourceType": "Provenance",
+        "id": "example",
+        "text": {
+            "status": "generated",
+            "div": "<div xmlns='http://www.w3.org/1999/xhtml'></div>"
+        },
+        "target": [
+            {
+                "reference": "Procedure/example/_history/1"
+            }
+        ],
+        "occurredPeriod": {
+            "start": "2015-06-27",
+            "end": "2015-06-28"
+        },
+        "recorded": "2015-06-27T08:39:24+10:00",
+        "policy": [
+            "http://acme.com/fhir/Consent/25"
+        ],
+        "location": {
+            "reference": "Location/1"
+        },
+        "reason": [
+            {
+                "coding": [
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "3457005",
+                        "display": "Referral"
+                    }
+                ]
+            }
+        ],
+        "agent": [
+            {
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                            "code": "AUT"
+                        }
+                    ]
+                },
+                "who": {
+                    "reference": "Practitioner/xcda-author"
+                }
+            },
+            {
+                "id": "a1",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                            "code": "DEV"
+                        }
+                    ]
+                },
+                "who": {
+                    "reference": "Device/software"
+                }
+            }
+        ],
+        "entity": [
+            {
+                "role": "source",
+                "what": {
+                    "reference": "DocumentReference/example",
+                    "display": "CDA Document in XDS repository"
+                },
+                "agent": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
+                                    "code": "transmitter"
+                                }
+                            ]
+                        },
+                        "who": {
+                            "reference": "Organization/1",
+                            "display": "Acme Healthcare"
+                        }
+                    }   
+                ]
+            }
+        ]
+    };
+
+    USCoreProvenance usCoreProvenanceProfile = check parser:parse(inputProvenance, USCoreProvenance).ensureType();
+    USCoreProvenanceEntity[]? entity = usCoreProvenanceProfile.entity;
+    if entity is USCoreProvenanceEntity[] {
+        USCoreProvenanceAgentProvenanceTransmitter[]? provenanceTransmitter = entity[0].agent;
+
+        if provenanceTransmitter is USCoreProvenanceAgentProvenanceTransmitter[] {
+            test:assertEquals(provenanceTransmitter[0].who.reference, "Organization/1", "Provenance transmitter reference is not as expected");
+        }
+    }
+}

--- a/native/fhir-to-bal-lib/src/test/resources/ballerina.tests/r5/test_content_reference.bal
+++ b/native/fhir-to-bal-lib/src/test/resources/ballerina.tests/r5/test_content_reference.bal
@@ -1,0 +1,219 @@
+import ballerina/test;
+import ballerinax/health.fhir.r5.international500;
+import ballerinax/health.fhir.r5.parser;
+
+@test:Config {}
+function testReferredFromInternational() returns error? {
+    json internationalBodyStructureInput = {
+        "resourceType": "BodyStructure",
+        "id": "fetus",
+        "text": {
+            "status": "generated",
+            "div": "<div xmlns='http://www.w3.org/1999/xhtml'></div>"
+        },
+        "identifier": [
+            {
+                "system": "http://goodhealth.org/bodystructure/identifiers",
+                "value": "12345"
+            }
+        ],
+        "includedStructure": [
+            {
+                "structure": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "83418008",
+                            "display": "Entire fetus (body structure)"
+                        }
+                    ],
+                    "text": "Fetus"
+                }
+            }
+        ],
+        "description": "EDD 1/1/2017 confirmation by LMP",
+        "patient": {
+            "reference": "Patient/example"
+        }
+    };
+
+    json europeBaseBodyStructureInput = {
+        "resourceType": "BodyStructure",
+        "id": "example-body-structure-eu",
+        "meta": {
+            "profile": [
+                "http://hl7.eu/fhir/base-r5/StructureDefinition/BodyStructure-eu"
+            ]
+        },
+        "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: BodyStructure example-body-structure-eu</b></p><a name=\"example-body-structure-eu\"> </a><a name=\"hcexample-body-structure-eu\"> </a><a name=\"example-body-structure-eu-en-US\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\"/><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-BodyStructure-eu.html\">Body structure (EU base)</a></p></div><p><b>morphology</b>: <span title=\"Codes:{http://snomed.info/sct 339008}\">Blister</span></p><h3>IncludedStructures</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Structure</b></td><td><b>Laterality</b></td><td><b>Qualifier</b></td></tr><tr><td style=\"display: none\">*</td><td><span title=\"Codes:{http://snomed.info/sct 8205005}\">Wrist</span></td><td><span title=\"Codes:{http://snomed.info/sct 7771000}\">Left</span></td><td><span title=\"Codes:{http://snomed.info/sct 351726001}\">Below</span></td></tr></table><p><b>patient</b>: <a href=\"Patient-patient-eu-core-example.html\">John Doe  Male, DoB: 1980-01-01</a></p></div>"
+        },
+        "morphology": {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "339008",
+                    "display": "Blister"
+                }
+            ]
+        },
+        "includedStructure": [
+            {
+                "structure": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "8205005",
+                            "display": "Wrist"
+                        }
+                    ]
+                },
+                "laterality": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "7771000",
+                            "display": "Left"
+                        }
+                    ]
+                },
+                "qualifier": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "351726001",
+                                "display": "Below"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "excludedStructure": [
+            {
+                "structure": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "83418008",
+                            "display": "Entire fetus (body structure)"
+                        }
+                    ],
+                    "text": "Fetus"
+                }
+            }
+        ],
+        "patient": {
+            "reference": "Patient/patient-eu-core-example"
+        }
+    };
+
+    international500:BodyStructure international500BodyStructure = check parser:parse(internationalBodyStructureInput, international500:BodyStructure).ensureType();
+    international500:BodyStructureIncludedStructure[]? internationalIncludedStructure = international500BodyStructure.includedStructure;
+
+    BodyStructureEu euBodyStructure = check parser:parse(europeBaseBodyStructureInput, BodyStructureEu).ensureType();
+    international500:BodyStructureIncludedStructure[]? euExcludedStructure = euBodyStructure.excludedStructure;
+
+    test:assertEquals(internationalIncludedStructure, euExcludedStructure, "Parsed BodyStructure models are not equal");
+}
+
+@test:Config {}
+function testReferredFromLocal() returns error? {
+    json inputEuCorePatient = {
+        "resourceType": "Patient",
+        "id": "patient-eu-core-example",
+        "meta": {
+            "profile": [
+                "http://hl7.eu/fhir/base-r5/StructureDefinition/patient-eu-core"
+            ]
+        },
+        "text": {
+            "status": "generated",
+            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: Patient patient-eu-core-example</b></p><a name=\"patient-eu-core-example\"> </a><a name=\"hcpatient-eu-core-example\"> </a><a name=\"patient-eu-core-example-en-US\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\"/><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-patient-eu-core.html\">Patient (EU core)</a></p></div><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\">John Doe  Male, DoB: 1980-01-01</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Ways to contact the Patient\">Contact Detail</td><td colspan=\"3\"><ul><li>ph: 555-1234(Home)</li><li>123 Example Street Example City EX 12345 EX </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Patient Links\">Links:</td><td colspan=\"3\"><ul><li>Managing Organization: <a href=\"Organization-organization-eu-core-example.html\">Organization Example Health Organization</a></li></ul></td></tr></table></div>"
+        },
+        "name": [
+            {
+                "family": "Doe",
+                "given": [
+                    "John"
+                ]
+            }
+        ],
+        "telecom": [
+            {
+                "system": "phone",
+                "value": "555-1234",
+                "use": "home"
+            }
+        ],
+        "gender": "male",
+        "birthDate": "1980-01-01",
+        "address": [
+            {
+                "line": [
+                    "123 Example Street"
+                ],
+                "city": "Example City",
+                "state": "EX",
+                "postalCode": "12345",
+                "country": "EX"
+            }
+        ],
+        "managingOrganization": {
+            "reference": "Organization/organization-eu-core-example"
+        },
+        "link": [
+            {
+                "other": {
+                    "reference": "Patient/patient-eu-core-example"
+                },
+                "type": "refer"
+            }
+        ],
+        "communication": [
+            {
+                "language": {
+                    "coding": [
+                        {
+                            "system": "urn:ietf:bcp:47",
+                            "code": "nl-NL",
+                            "display": "Dutch"
+                        }
+                    ]
+                },
+                "preferred": true,
+                "link": [
+                    {
+                        "other": {
+                            "reference": "Patient/patient-eu-core-example"
+                        },
+                        "type": "refer"
+                    }
+                ]
+            }
+        ]
+    };
+
+    PatientEuCore euCorePatientProfile = check parser:parse(inputEuCorePatient, PatientEuCore).ensureType();
+    PatientEuLink[]? euCorePatientProfileLink = euCorePatientProfile.link;
+
+    string euCorePatientProfileLinkType = "";
+    if euCorePatientProfileLink is PatientEuLink[] {
+        euCorePatientProfileLinkType = euCorePatientProfileLink[0].'type;
+    }
+
+
+    string communicationLinkType = "";
+    PatientEuCoreCommunication[]? communication = euCorePatientProfile.communication;
+    if communication is PatientEuCoreCommunication[] {
+        PatientEuLink[]? communicationLink = communication[0].link;
+
+        if communicationLink is PatientEuCoreLink[] {
+            communicationLinkType = communicationLink[0].'type;
+        }
+    }
+
+    test:assertEquals(euCorePatientProfileLinkType, communicationLinkType, "Link type in Patient and Communication is not equal");
+}

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
@@ -201,10 +201,6 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
         return includedIGConfigs;
     }
 
-    public List<DependencyConfig> getDependencyConfigs() {
-        return dependencyConfigs;
-    }
-
     public List<String> getSearchParamConfigs() {
         return searchParamConfigs;
     }

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
@@ -25,7 +25,6 @@ import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.BallerinaProjectC
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.config.BallerinaProjectToolConfig;
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.AggregatedService;
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.BallerinaService;
-import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.generator.AggregatedServiceGenerator;
 
 import java.io.Console;
 import java.nio.file.Files;

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/MetaGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/MetaGenerator.java
@@ -30,7 +30,12 @@ import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.BallerinaSe
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.FHIRProfile;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 
 public class MetaGenerator extends AbstractFHIRTemplateGenerator {
 

--- a/native/fhir-to-bal-template/src/main/resources/template/r5ModuleMd.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/r5ModuleMd.vm
@@ -5,7 +5,7 @@
 # FHIR $service.getName() API Template
 
 ## Overview
-This Ballerina-based template implementation provides a RESTful FHIR API for managing `${service.getName()}` resources, adhering to the FHIR R5 specification. The API is designed to support CRUD operations International FHIR R5 ${service.getName()} FHIR API.
+This Ballerina-based template implementation provides a RESTful FHIR API for managing #if($service.getName().isEmpty()) FHIR #else $service.getName() #end resources, adhering to the FHIR R5 specification. The API is designed to support CRUD operations FHIR R5 #if($service.getName().isEmpty()) FHIR APIs #else $service.getName() FHIR API #end.
 
 | Module/Element       | Version |
 | -------------------- | ------- |
@@ -18,13 +18,8 @@ This Ballerina-based template implementation provides a RESTful FHIR API for man
 ## Prerequisites
 - [Ballerina](https://ballerina.io/downloads/) (2201.10.2 or later)
 - [VSCode](https://code.visualstudio.com/download) as the IDE and install the required vscode plugins
-    - Ballerina (https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina)
-    - Ballerina Integrator (https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina-integrator)
-
-### Pull the Template from Central
-```sh
-bal new -t $metaConfig.getOrg()/$templateName $apiName
-```
+- Ballerina (https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina)
+- Ballerina Integrator (https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina-integrator)
 
 ### Run the Template
 Run the Ballerina project created by the service template by executing:
@@ -41,60 +36,60 @@ Now, the service will be invoked and return an `OperationOutcome`, until the cod
 
 ## API Endpoints
 
-### Retrieve a ${service.getName()} by ID
+### Retrieve a #if($service.getName().isEmpty()) Resource #else $service.getName() #end by ID
 ```http
-GET /fhir/r5/${service.getName()}/{id}
+GET /fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end/{id}
 ```
 - **Response:** Returns a `${service.getName()}` resource or an `OperationOutcome` if not found.
 
-### Retrieve a Specific Version of a ${service.getName()} Resource
+### Retrieve a Specific Version of a #if($service.getName().isEmpty())#else$service.getName()#end Resource
 ```http
-GET /fhir/r5/${service.getName()}/{id}/_history/{vid}
+GET /fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end/{id}/_history/{vid}
 ```
 - **Response:** Returns a specific historical version of a `${service.getName()}` resource.
 
-### Search for ${service.getName()}s
+### Search for #if($service.getName().isEmpty())Resource#else$service.getName()#ends
 ```http
-GET /fhir/r5/${service.getName()}
+GET /fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end
 ```
 - **Response:** Returns a `Bundle` containing matching `$service.getName()` resources.
 
 ### Create a ${service.getName()} Resource
 ```http
-POST /fhir/r5/${service.getName()}
+POST /fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end
 ```
 - **Request Body:** `${service.getName()}` resource.
 - **Response:** Returns the created `${service.getName()}` resource.
 
 ### Update a ${service.getName()} Resource
 ```http
-PUT /fhir/r5/${service.getName()}/{id}
+PUT /fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end/{id}
 ```
 - **Request Body:** Updated `${service.getName()}` resource.
 - **Response:** Returns the updated `${service.getName()}` resource.
 
 ### Patch a ${service.getName()} Resource
 ```http
-PATCH /fhir/r5/${service.getName()}/{id}
+PATCH /fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end/{id}
 ```
 - **Request Body:** JSON Patch object.
 - **Response:** Returns the updated `${service.getName()}` resource.
 
 ### Delete a ${service.getName()} Resource
 ```http
-DELETE /fhir/r5/${service.getName()}/{id}
+DELETE /fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end/{id}
 ```
 - **Response:** Returns an `OperationOutcome` indicating success or failure.
 
-### Retrieve Update History for a ${service.getName()}
+### Retrieve Update History for a #if($service.getName().isEmpty())Resource#else$service.getName()#end
 ```http
-GET /fhir/r5/${service.getName()}/{id}/_history
+GET /fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end/{id}/_history
 ```
 - **Response:** Returns a `Bundle` of historical versions of the `${service.getName()}` resource.
 
-### Retrieve Update History for All ${service.getName()}s
+### Retrieve Update History for All #if($service.getName().isEmpty())Resource#else$service.getName()#ends
 ```http
-GET /fhir/r5/${service.getName()}/_history
+GET /fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end/_history
 ```
 - **Response:** Returns a `Bundle` of historical versions of all `${service.getName()}` resources.
 
@@ -111,18 +106,18 @@ Modify `apiConfig` in the `fhirr5:Listener` initialization if needed to adjust s
 The `apiConfig` object is used to configure the FHIR API. By default, it consists of the search parameters for the FHIR API defined for the Implementation Guide. If there are custom search parameters, they can be defined in the `apiConfig` object. Following is an example of how to add a custom search parameter:
 
 ```json
-        searchParameters: [
-          ....
-          {
-              name: "custom-search-parameter", // Custom search parameter name
-              active: true // Whether the search parameter is active
-              information: { // Optional information about the search parameter
-                  description: "Custom search parameter description",
-                  builtin: false,
-              }
-          }
-        ]
-  ```
+searchParameters: [
+....
+{
+name: "custom-search-parameter", // Custom search parameter name
+active: true // Whether the search parameter is active
+information: { // Optional information about the search parameter
+description: "Custom search parameter description",
+builtin: false,
+}
+}
+]
+```
 
 #### Adding a Custom Operation
 
@@ -130,36 +125,36 @@ Following are the steps to add a custom operation to the FHIR API template:
 
 1. The `apiConfig` object is used to configure the FHIR API. By default, it consists of the operations for the FHIR API defined for the Implementation Guide. If there are custom operations, they can be defined in the `apiConfig` object. Following is an example of how to add a custom operation:
 ```json
-        operations: [
-          ....
-          {
-              name: "custom-operation", // Custom operation name
-              active: true // Whether the operation is active
-              information: { // Optional information about the operation
-                  description: "Custom operation description",
-                  builtin: false,
-              }
-          }
-        ]
-  ```
-  2. Add the context related to the custom operation in the service.bal file. Following is an example of how to add a custom operation:
-  ```typescript
-    isolated resource function post fhir/r5/${service.getName()}/\$custom\-operation(r5:FHIRContext fhirContext, ${service.getName()} procedure) returns r5:OperationOutcome|r5:FHIRError {
-        return r5:createFHIRError("Not implemented", r5:ERROR, r5:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
-    }
-  ```
+operations: [
+....
+{
+name: "custom-operation", // Custom operation name
+active: true // Whether the operation is active
+information: { // Optional information about the operation
+description: "Custom operation description",
+builtin: false,
+}
+}
+]
+```
+2. Add the context related to the custom operation in the service.bal file. Following is an example of how to add a custom operation:
+```typescript
+isolated resource function post fhir/r5/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end/\$custom\-operation(r5:FHIRContext fhirContext, #if($service.getName().isEmpty()){resource_type}#else$service.getName()#end procedure) returns r5:OperationOutcome|r5:FHIRError {
+return r5:createFHIRError("Not implemented", r5:ERROR, r5:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+}
+```
 
 #### Adding a Custom Profile/Combination of Profiles
 Additionally, If you want to have a custom profile or a combination of profiles served from this same API template, you can add them to this FHIR API template. To add a custom profile, follow the steps below:
 
 - Add the profile type to the aggregated resource type.
-  - **Example:** `public type ${service.getName()} r5:${service.getName()}|<Other_${service.getName()}_Profile>;`
-- Add the new profile URL in `api_config.bal` file. You need to add it as a string inside the `profiles` array.
-  - **Example:**
+- **Example:** `public type #if($service.getName().isEmpty()){resource_type}#else$service.getName()#end r5:#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end|<Other_${service.getName()}_Profile>;`
+    - Add the new profile URL in `api_config.bal` file. You need to add it as a string inside the `profiles` array.
+    - **Example:**
     ```ballerina
-    profiles: ["http://hl7.org/fhir/StructureDefinition/${service.getName()}", "new_profile_url"]
+    profiles: ["http://hl7.org/fhir/StructureDefinition/#if($service.getName().isEmpty()){resource_type}#else$service.getName()#end", "new_profile_url"]
     ```
 
-## License
-This project is subject to the [WSO2 Software License](../LICENCE).
+    ## License
+    This project is subject to the [WSO2 Software License](../LICENCE).
 

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirPackageGenHandler.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirPackageGenHandler.java
@@ -38,8 +38,6 @@ import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
-import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.*;
-
 /**
  * Handler for package generation tool.
  */
@@ -141,14 +139,17 @@ public class FhirPackageGenHandler implements Handler {
                             getAsJsonObject("versionConfigs").
                             getAsJsonObject(fhirVersion);
 
-                    final String r5Repository = jsonPath.getAsJsonPrimitive("repository").getAsString();
-                    final String r5BasePackage = jsonPath.getAsJsonPrimitive("basePackage").getAsString();
+                    final String repository = jsonPath.getAsJsonPrimitive("repository").getAsString();
+                    final String basePackage = jsonPath.getAsJsonPrimitive("basePackage").getAsString();
+                    final String internationalPackage = jsonPath.getAsJsonPrimitive("internationalPackage").getAsString();
 
-                    JsonElement overrideConfigRepository = new Gson().toJsonTree(r5Repository);
-                    JsonElement overrideConfigBase = new Gson().toJsonTree(r5BasePackage);
+                    JsonElement overrideConfigRepository = new Gson().toJsonTree(repository);
+                    JsonElement overrideConfigBase = new Gson().toJsonTree(basePackage);
+                    JsonElement overrideConfigInternational = new Gson().toJsonTree(internationalPackage);
 
                     toolConfigInstance.overrideConfig("packageConfig.repository", overrideConfigRepository);
                     toolConfigInstance.overrideConfig("packageConfig.basePackage", overrideConfigBase);
+                    toolConfigInstance.overrideConfig("packageConfig.internationalPackage", overrideConfigInternational);
                 }
                 if (dependentIgs != null && dependentIgs.length > 0) {
                     // Create a JSON array from the String array

--- a/native/health-cli/src/main/resources/tool-config.json
+++ b/native/health-cli/src/main/resources/tool-config.json
@@ -19,11 +19,13 @@
             "versionConfigs": {
               "r4": {
                 "repository": "https://github.com/ballerina-platform/module-ballerinax-health.fhir.r4",
-                "basePackage": "ballerinax/health.fhir.r4"
+                "basePackage": "ballerinax/health.fhir.r4",
+                "internationalPackage": "ballerinax/health.fhir.r4.international401"
               },
               "r5": {
                 "repository": "https://github.com/ballerina-platform/module-ballerinax-health.fhir.r5",
-                "basePackage": "ballerinax/health.fhir.r5"
+                "basePackage": "ballerinax/health.fhir.r5",
+                "internationalPackage": "ballerinax/health.fhir.r5.international500"
               }
             }
           },

--- a/native/health-cli/src/test/java/TestRunner.java
+++ b/native/health-cli/src/test/java/TestRunner.java
@@ -107,7 +107,9 @@ public class TestRunner {
         argsMap.put("--package-name", packageName); // FOR PACKAGE
         argsMap.put("--package-version", packageVersion); // FOR PACKAGE
         argsMap.put("--dependency", null); // FOR PACKAGE
-        //        argsMap.put("--dependent-package", orgName + "/" + packageName); // FOR TEMPLATE
+        // argsMap.put("--dependent-package", orgName + "/" + packageName); // FOR TEMPLATE
+        // argsMap.put("--aggregate", true); // FOR TEMPLATE
+        // argsMap.put("--resources", "Patient,Observation,Condition"); // FOR TEMPLATE
         argsMap.put("--org-name", orgName);
         argsMap.put("--included-profile", null);
         argsMap.put("--excluded-profile", null);
@@ -160,7 +162,9 @@ public class TestRunner {
         argsMap.put("--package-name", packageName); // FOR PACKAGE
         argsMap.put("--package-version", packageVersion); // FOR PACKAGE
         argsMap.put("--dependency", null); // FOR PACKAGE
-        //        argsMap.put("--dependent-package", orgName + "/" + packageName); // FOR TEMPLATE
+        // argsMap.put("--dependent-package", orgName + "/" + packageName); // FOR TEMPLATE
+        // argsMap.put("--aggregate", false); // FOR TEMPLATE
+        // argsMap.put("--resources", "Patient,Practitioner"); // FOR TEMPLATE
         argsMap.put("--org-name", orgName);
         argsMap.put("--included-profile", null);
         argsMap.put("--excluded-profile", null);

--- a/native/health-cli/src/test/resources/profiles.EuropeBase/StructureDefinition-patient-eu-core.json
+++ b/native/health-cli/src/test/resources/profiles.EuropeBase/StructureDefinition-patient-eu-core.json
@@ -3236,6 +3236,338 @@
             "map": "n/a"
           }
         ]
+      },
+      {
+        "id": "Patient.communication",
+        "path": "Patient.communication",
+        "short": "A language which may be used to communicate with the patient about his or her health",
+        "definition": "A language which may be used to communicate with the patient about his or her health.",
+        "comment": "If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes, then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required.",
+        "requirements": "If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency are important things to keep track of both for patient and other persons of interest.",
+        "min": 0,
+        "max": "*",
+        "base": {
+          "path": "Patient.communication",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "BackboneElement"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "mustSupport": false,
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "LanguageCommunication"
+          },
+          {
+            "identity": "interface",
+            "map": "ParticipantLiving.communication"
+          },
+          {
+            "identity": "cda",
+            "map": "patient.languageCommunication"
+          }
+        ]
+      },
+      {
+        "id": "Patient.communication.id",
+        "path": "Patient.communication.id",
+        "representation": [
+          "xmlAttr"
+        ],
+        "short": "Unique id for inter-element referencing",
+        "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Element.id",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                "valueUrl": "string"
+              }
+            ],
+            "code": "http://hl7.org/fhirpath/System.String"
+          }
+        ],
+        "condition": [
+          "ele-1"
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "n/a"
+          }
+        ]
+      },
+      {
+        "id": "Patient.communication.extension",
+        "path": "Patient.communication.extension",
+        "short": "Additional content defined by implementations",
+        "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+        "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+        "alias": [
+          "extensions",
+          "user content"
+        ],
+        "min": 0,
+        "max": "*",
+        "base": {
+          "path": "Element.extension",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          },
+          {
+            "key": "ext-1",
+            "severity": "error",
+            "human": "Must have either extensions or value[x], not both",
+            "expression": "extension.exists() != value.exists()",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "n/a"
+          }
+        ]
+      },
+      {
+        "id": "Patient.communication.modifierExtension",
+        "path": "Patient.communication.modifierExtension",
+        "short": "Extensions that cannot be ignored even if unrecognized",
+        "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and managable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+        "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+        "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](extensibility.html#modifierExtension).",
+        "alias": [
+          "extensions",
+          "user content",
+          "modifiers"
+        ],
+        "min": 0,
+        "max": "*",
+        "base": {
+          "path": "BackboneElement.modifierExtension",
+          "min": 0,
+          "max": "*"
+        },
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          },
+          {
+            "key": "ext-1",
+            "severity": "error",
+            "human": "Must have either extensions or value[x], not both",
+            "expression": "extension.exists() != value.exists()",
+            "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+          }
+        ],
+        "isModifier": true,
+        "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+        "isSummary": true,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "N/A"
+          }
+        ]
+      },
+      {
+        "id": "Patient.communication.language",
+        "path": "Patient.communication.language",
+        "short": "The language which can be used to communicate with the patient about his or her health",
+        "definition": "The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. \"en\" for English, or \"en-US\" for American English versus \"en-AU\" for Australian English.",
+        "comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
+        "requirements": "Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect.",
+        "min": 1,
+        "max": "1",
+        "base": {
+          "path": "Patient.communication.language",
+          "min": 1,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "mustSupport": false,
+        "isModifier": false,
+        "isSummary": false,
+        "binding": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "Language"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+              "valueBoolean": true
+            }
+          ],
+          "strength": "required",
+          "description": "IETF language tag for a human language",
+          "valueSet": "http://hl7.org/fhir/ValueSet/all-languages|5.0.0",
+          "additional": [
+            {
+              "purpose": "starter",
+              "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+            }
+          ]
+        },
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "PID-15, LAN-2"
+          },
+          {
+            "identity": "rim",
+            "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code"
+          },
+          {
+            "identity": "cda",
+            "map": ".languageCode"
+          }
+        ]
+      },
+      {
+        "id": "Patient.communication.preferred",
+        "path": "Patient.communication.preferred",
+        "short": "Language preference indicator",
+        "definition": "Indicates whether or not the patient prefers this language (over other languages he masters up a certain level).",
+        "comment": "This language is specifically identified for communicating healthcare information.",
+        "requirements": "People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "Patient.communication.preferred",
+          "min": 0,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ],
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "mustSupport": false,
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "PID-15"
+          },
+          {
+            "identity": "rim",
+            "map": "preferenceInd"
+          },
+          {
+            "identity": "cda",
+            "map": ".preferenceInd"
+          }
+        ]
+      },
+      {
+        "id": "Patient.communication.link",
+        "path": "Patient.communication.link",
+        "short": "Link to a Patient or RelatedPerson resource that concerns the same actual individual",
+        "definition": "Link to a Patient or RelatedPerson resource that concerns the same actual individual.",
+        "comment": "There is no assumption that linked patient records have mutual links.",
+        "requirements": "There are multiple use cases:   \n\n* Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and \n* Distribution of patient information across multiple servers.",
+        "min": 0,
+        "max": "*",
+        "base": {
+          "path": "Patient.communication.link",
+          "min": 0,
+          "max": "*"
+        },
+        "contentReference": "#Patient.link",
+        "constraint": [
+          {
+            "key": "ele-1",
+            "severity": "error",
+            "human": "All FHIR elements must have a @value or children",
+            "expression": "hasValue() or (children().count() > id.count())",
+            "xpath": "@value|f:*|h:div",
+            "source": "http://hl7.org/fhir/StructureDefinition/Element"
+          }
+        ],
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "OBX.7"
+          },
+          {
+            "identity": "rim",
+            "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+          }
+        ]
       }
     ]
   },
@@ -3292,6 +3624,123 @@
             "profile": [
               "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
             ]
+          }
+        ]
+      },
+      {
+        "id": "Patient.communication",
+        "path": "Patient.communication",
+        "short": "A language which may be used to communicate with the patient about his or her health",
+        "definition": "A language which may be used to communicate with the patient about his or her health.",
+        "comment": "If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes, then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required.",
+        "requirements": "If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency are important things to keep track of both for patient and other persons of interest.",
+        "min": 0,
+        "max": "*",
+        "type": [
+          {
+            "code": "BackboneElement"
+          }
+        ],
+        "mustSupport": false,
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "rim",
+            "map": "LanguageCommunication"
+          },
+          {
+            "identity": "interface",
+            "map": "ParticipantLiving.communication"
+          },
+          {
+            "identity": "cda",
+            "map": "patient.languageCommunication"
+          }
+        ]
+      },
+      {
+        "id": "Patient.communication.language",
+        "path": "Patient.communication.language",
+        "short": "The language which can be used to communicate with the patient about his or her health",
+        "definition": "The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. \"en\" for English, or \"en-US\" for American English versus \"en-AU\" for Australian English.",
+        "comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
+        "requirements": "Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect.",
+        "min": 1,
+        "max": "1",
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ],
+        "mustSupport": false,
+        "isModifier": false,
+        "isSummary": false,
+        "binding": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+              "valueString": "Language"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+              "valueBoolean": true
+            }
+          ],
+          "strength": "required",
+          "description": "IETF language tag for a human language",
+          "valueSet": "http://hl7.org/fhir/ValueSet/all-languages|5.0.0",
+          "additional": [
+            {
+              "purpose": "starter",
+              "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+            }
+          ]
+        },
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "PID-15, LAN-2"
+          },
+          {
+            "identity": "rim",
+            "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code"
+          },
+          {
+            "identity": "cda",
+            "map": ".languageCode"
+          }
+        ]
+      },
+      {
+        "id": "Patient.communication.preferred",
+        "path": "Patient.communication.preferred",
+        "short": "Language preference indicator",
+        "definition": "Indicates whether or not the patient prefers this language (over other languages he masters up a certain level).",
+        "comment": "This language is specifically identified for communicating healthcare information.",
+        "requirements": "People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method.",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ],
+        "mustSupport": false,
+        "isModifier": false,
+        "isSummary": false,
+        "mapping": [
+          {
+            "identity": "v2",
+            "map": "PID-15"
+          },
+          {
+            "identity": "rim",
+            "map": "preferenceInd"
+          },
+          {
+            "identity": "cda",
+            "map": ".preferenceInd"
           }
         ]
       }


### PR DESCRIPTION
## Purpose
Resolves the Issue: [[Ballerina Health Tool] Parsing Error for tool generated UDSPlusDeIdentifyDataUrlsParameterParameter](https://github.com/wso2-enterprise/open-healthcare/issues/1766)

## Goals

1. Include elements that have a contentReference (referring to international or local elements).
2. Support references to locally defined elements within the same resource.
3. Fix the maxLength constraint issue with array types.

## Approach
The `contentReference `in an `ElementDefinition `points to another element whose rules should apply to the current element. This can either refer to:

- An international element from standard HL7/FHIR packages.
- A local element defined within the same resource.

Example of such an element:
```
{
      "id" : "Parameters.parameter.part",
      "path" : "Parameters.parameter.part",
      "short" : "Named part of a multi-part parameter",
      "definition" : "A named part of a multi-part parameter.",
      "comment" : "Only one level of nested parameters is allowed.",
      "min" : 0,
      "max" : "*",
      "base" : {
        "path" : "Parameters.parameter.part",
        "min" : 0,
        "max" : "*"
      },
      "contentReference" : "http://hl7.org/fhir/StructureDefinition/Parameters#Parameters.parameter",
      "constraint" : [{
        "key" : "ele-1",
        "severity" : "error",
        "human" : "All FHIR elements must have a @value or children",
        "expression" : "hasValue() or (children().count() > id.count())",
        "xpath" : "@value|f:*|h:div",
        "source" : "http://hl7.org/fhir/StructureDefinition/Element"
      }],
      "isModifier" : false,
      "isSummary" : true
    }
```
Such elements do not define a type (i.e., `ElementDefinition.TypeRefComponent` is absent):

```
"type" : [{
    "code" : "BackboneElement"
}]
```
**Current Issue**
Since the tool uses TypeRefComponent to identify datatypes, these contentReference elements are skipped, causing parsing errors.

**Solution**
To fix this a dummy datatype temporarily assigned to ensure the tool picks up the element. Later, the functions override the type based on the reference content.

There are two main cases:

1. **International Reference**
In this case the contentReference look like:

`"contentReference" : "http://hl7.org/fhir/StructureDefinition/Parameters#Parameters.parameter"`

- The part after # is used to determine the type.
- The tool uses this to generate imports automatically via VTL.

2. **Local Reference**
In this case the contentReference look like:

`"contentReference": "#ExplanationOfBenefit.item.reviewOutcome"`

or

`"contentReference": "#Provenance.agent:ProvenanceTransmitter"`
 
- These refer to elements inside the same resource.
- The type is determined from the reference string.
- Extra conditions are used to avoid confusions (e.g., in cases where elements share names --> Observation).

## User stories
> The generated Ballerina packages will now include `contentReference` elements.

## Release note
> Adds support for `contentReference` elements and fixes `maxLength` handling in arrays.

## Documentation
N/A
This is bug fix and there won't be any documentation required to be updated.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   R4 Packages: 99.99%
   R5 Packages: 99.98%

 - Integration tests: N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
 - Ran FindSecurityBugs plugin and verified report? No
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK: 21
Ballerina: 2201.12.3
OS: Windows
 
## Learning

1. [HAPI FHIR – ElementDefinition#contentReference](https://hapifhir.io/hapi-fhir/apidocs/hapi-fhir-structures-r4/org/hl7/fhir/r4/model/ElementDefinition.html#contentReference)
2. [UDS+ De-identify Operation Structure](https://www.fhir.org/guides/hrsa/uds-plus/StructureDefinition-uds-plus-deidentify-operation-data-urls-parameter.html)
3. [FHIR R5: ExplanationOfBenefit.item.reviewOutcome](https://hl7.org/fhir/R5/explanationofbenefit.html#XExplanationOfBenefit.item.reviewOutcome)
4. [US Core: Vital Signs](https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-vital-signs.html)