### PR TITLE
Revert "[Health-Tool][Temp-Fix] Generates Slice Elements of the Root Element"

### DIFF
--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/Element.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/model/Element.java
@@ -48,9 +48,6 @@ public class Element {
     // Saves the content reference element is available.
     private String contentReference;
 
-    ///  Todo: Stores the resource extension properties. Verify again.
-    private Map<String, String> elementProperties = new HashMap<>();
-
     public String getDataType() {
         return dataType;
     }
@@ -213,13 +210,5 @@ public class Element {
 
     public String getContentReference() {
         return contentReference;
-    }
-
-    public void setElementProperties(Map<String, String> elementProperties) {
-        this.elementProperties = elementProperties;
-    }
-
-    public Map<String, String> getElementProperties() {
-        return elementProperties;
     }
 }

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/AbstractResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/AbstractResourceContextGenerator.java
@@ -38,8 +38,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.HashSet;
 import java.util.regex.Pattern;
-import java.util.List;
-import java.util.ArrayList;
 
 import static org.wso2.healthcare.fhir.ballerina.packagegen.tool.ToolConstants.CONSTRAINTS_LIB_IMPORT;
 
@@ -150,43 +148,6 @@ public abstract class AbstractResourceContextGenerator {
                     }
                 }
             }
-        } else if (element.getPath().split("\\.").length == 2 &&
-                element.getPath().split("\\.")[element.getPath().split("\\.").length - 1].equals("extension")) {
-
-            /// Todo: Verify the conditions with other IGs. Tested for USCore700
-
-            HashMap<String, Element> childElements = new HashMap<>();
-            element.setDataType("BackboneElement");
-            element.setDescription("Slice of an Extended Element");
-
-            Element id = new Element();
-            id.setName("id");
-            id.setDataType("string");
-            id.setDescription(element.getDescription());
-            id.setPath(element.getPath() + ".id");
-
-            Element uri = new Element();
-            List<String> fixedValue = new ArrayList<>();
-            fixedValue.add(element.getElementProperties().get("fixedValueUrl"));
-            uri.setName("url");
-            uri.setDataType("uri");
-            uri.setFixedValue(fixedValue);
-            uri.setDescription(element.getDescription());
-            uri.setPath(element.getPath() + ".url");
-
-            if (element.getElementProperties().containsKey("complexExtension")) {
-                Element extension = new Element();
-                extension.setName("extension");
-                extension.setDataType("Extension");
-                extension.setArray(true);
-                extension.setDescription(element.getDescription());
-                extension.setPath(element.getPath() + ".extension");
-                childElements.put(extension.getName(), extension);
-            }
-
-            childElements.put(id.getName(), id);
-            childElements.put(uri.getName(), uri);
-            element.setChildElements(childElements);
         }
     }
 

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r4/R4ResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r4/R4ResourceContextGenerator.java
@@ -323,16 +323,6 @@ public class R4ResourceContextGenerator extends AbstractResourceContextGenerator
             element.setContentReference(elementDefinition.getContentReference());
         }
 
-        /// Todo: Catch extensions which are slices. Verify
-        if ("Extension".equals(type.getCode()) && elementDefinition.getSliceName() != null && !elementDefinition.getSliceName().isEmpty()){
-            if (elementDefinition.hasExtension()){
-                element.getElementProperties().put("complexExtension", elementDefinition.getExtension().getFirst().getUrl());
-            }
-            if(!type.getProfile().isEmpty()){
-                element.getElementProperties().put("fixedValueUrl", type.getProfile().getFirst().getValue());
-            }
-        }
-
         if (ToolConstants.ELEMENT.equals(type.getCode())) {
             element.setDataType(ToolConstants.ELEMENT + CommonUtil.toCamelCase(name));
         } else if (isReferredElement && GeneratorUtils.isReferredFromInternational(element.getContentReference())) {
@@ -442,11 +432,9 @@ public class R4ResourceContextGenerator extends AbstractResourceContextGenerator
 
     private void populateResourceSliceElementsMap(Element element) {
         LOG.debug("Started: Resource Slice Element Map population");
-        /// Todo: Removed to get the extended element slices in the documentation
-        /// Tested for USCore. Effect on other profiles need to be verified
-        // if (ToolConstants.DATA_TYPE_EXTENSION.equals(element.getDataType()) && element.isSlice()) {
-        //    return;
-        // }
+        if (ToolConstants.DATA_TYPE_EXTENSION.equals(element.getDataType()) && element.isSlice()) {
+            return;
+        }
         if (element.hasChildElements()) {
             for (Map.Entry<String, Element> childEntry : element.getChildElements().entrySet()) {
                 populateResourceSliceElementsMap(childEntry.getValue());


### PR DESCRIPTION
Reason: Generation of extended elements should be handled separately rather than being treated as resource elements of another resource. Thus the changes of this PR will be removed and addressed separately by another issue. 