### PR TITLE
Add --minimal flag for FHIR and CDS template generation

### DIFF
--- a/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/BallerinaCDSProjectConstants.java
+++ b/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/BallerinaCDSProjectConstants.java
@@ -78,6 +78,8 @@ public class BallerinaCDSProjectConstants {
     public static final String VERSION = "version";
     public static final String DISTRIBUTION = "distribution";
     public static final String AUTHORS = "authors";
+    public static final String PROJECT_MINIMAL = "project.minimal";
+    public static final String MINIMAL = "minimal";
 
     public static class PrintStrings {
         public static final String OVERWRITING_EXISTING_TEMPLATES = "[INFO] Overwriting the existing templates.";

--- a/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/config/BallerinaCDSProjectToolConfig.java
+++ b/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/config/BallerinaCDSProjectToolConfig.java
@@ -45,8 +45,8 @@ import static org.wso2.healthcare.cds.codegen.ballerina.tool.BallerinaCDSProject
 import static org.wso2.healthcare.cds.codegen.ballerina.tool.BallerinaCDSProjectConstants.PROJECT_PACKAGE_VERSION;
 import static org.wso2.healthcare.cds.codegen.ballerina.tool.BallerinaCDSProjectConstants.PROJECT_PACKAGE_BASE_PACKAGE;
 import static org.wso2.healthcare.cds.codegen.ballerina.tool.BallerinaCDSProjectConstants.BASE_PACKAGE;
-
-/**
+import static org.wso2.healthcare.cds.codegen.ballerina.tool.BallerinaCDSProjectConstants.PROJECT_MINIMAL;
+import static org.wso2.healthcare.cds.codegen.ballerina.tool.BallerinaCDSProjectConstants.MINIMAL;/**
  * Main config class to hold all the config objects.
  */
 public class BallerinaCDSProjectToolConfig extends AbstractToolConfig {
@@ -57,6 +57,7 @@ public class BallerinaCDSProjectToolConfig extends AbstractToolConfig {
     private String basePackage;
     private String dependentPackage;
     private final List<CdsHook> cdsHooks = new ArrayList<>();
+    private boolean minimal = false;
 
     @Override
     public void configure(ConfigType<?> configObj) throws CodeGenException {
@@ -77,6 +78,7 @@ public class BallerinaCDSProjectToolConfig extends AbstractToolConfig {
                 this.dependentPackage = jsonConfigObj
                         .getAsJsonPrimitive(DEPENDENT_PACKAGE).getAsString();
             }
+
 
             jsonConfigObj = ((JsonConfigType) configObj).getConfigObj().getAsJsonObject(HOOKS);
             loadCdsHooks(jsonConfigObj);
@@ -110,6 +112,9 @@ public class BallerinaCDSProjectToolConfig extends AbstractToolConfig {
             case PROJECT_PACKAGE_DEPENDENT_PACKAGE:
                 this.dependentPackage = value.getAsString();
                 break;
+            case PROJECT_MINIMAL:
+                this.minimal = value.getAsBoolean();
+                break;
             default:
                 LOG.warn("Invalid config path: " + jsonPath);
         }
@@ -119,6 +124,9 @@ public class BallerinaCDSProjectToolConfig extends AbstractToolConfig {
         for (int i = 0; i < igArray.size(); i++) {
             dependencyConfigs.add(new DependencyConfig(igArray.get(i).getAsJsonObject()));
         }
+    }
+    public void setMinimal(boolean minimal) {
+        this.minimal = minimal;
     }
 
     public MetadataConfig getMetadataConfig() {
@@ -144,4 +152,6 @@ public class BallerinaCDSProjectToolConfig extends AbstractToolConfig {
     public List<CdsHook> getCdsHooks() {
         return cdsHooks;
     }
+
+    public boolean isMinimal() {return minimal;}
 }

--- a/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/generator/BallerinaCDSProjectGenerator.java
+++ b/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/generator/BallerinaCDSProjectGenerator.java
@@ -70,19 +70,19 @@ public class BallerinaCDSProjectGenerator extends AbstractFHIRTemplateGenerator 
         } else {
             // Generate in subfolder (existing behavior)
             packagePath = this.getTargetDir() + ballerinaCDSProjectToolConfig.getMetadataConfig().getNamePrefix() + File.separator;
+        }
 
-            // Provide option to check and overwrite the existing package
-            Console console = System.console();
-            if (console != null && Files.exists(Paths.get(packagePath))) {
-                String input = console.readLine(CMD_MESSAGE_OVERRIDE_OUTPUT_DIRECTORY);
-                if (NO.equalsIgnoreCase(input)) {
-                    System.exit(ZERO);
-                } else if (YES.equalsIgnoreCase(input)) {
-                    System.out.println(BallerinaCDSProjectConstants.PrintStrings.OVERWRITING_EXISTING_TEMPLATES);
-                } else {
-                    System.out.println(BallerinaCDSProjectConstants.PrintStrings.INVALID_INPUT);
-                    System.exit(ZERO);
-                }
+        // Provide option to check and overwrite the existing package
+        Console console = System.console();
+        if (console != null && Files.exists(Paths.get(packagePath))) {
+            String input = console.readLine(CMD_MESSAGE_OVERRIDE_OUTPUT_DIRECTORY);
+            if (NO.equalsIgnoreCase(input)) {
+                System.exit(ZERO);
+            } else if (YES.equalsIgnoreCase(input)) {
+                System.out.println(BallerinaCDSProjectConstants.PrintStrings.OVERWRITING_EXISTING_TEMPLATES);
+            } else {
+                System.out.println(BallerinaCDSProjectConstants.PrintStrings.INVALID_INPUT);
+                System.exit(ZERO);
             }
         }
 

--- a/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/generator/BallerinaCDSProjectGenerator.java
+++ b/native/cds-bal-template/src/main/java/org/wso2/healthcare/cds/codegen/ballerina/tool/generator/BallerinaCDSProjectGenerator.java
@@ -61,19 +61,28 @@ public class BallerinaCDSProjectGenerator extends AbstractFHIRTemplateGenerator 
     public void generate(ToolContext toolContext, Map<String, Object> generatorProperties) throws CodeGenException {
 
         BallerinaCDSProjectToolConfig ballerinaCDSProjectToolConfig = (BallerinaCDSProjectToolConfig) generatorProperties.get(CONFIG);
-        String packagePath = this.getTargetDir() + ballerinaCDSProjectToolConfig.getMetadataConfig().getNamePrefix() + File.separator;
 
-        // Provide option to check and overwrite the existing package
-        Console console = System.console();
-        if (console != null && Files.exists(Paths.get(packagePath))) {
-            String input = console.readLine(CMD_MESSAGE_OVERRIDE_OUTPUT_DIRECTORY);
-            if (NO.equalsIgnoreCase(input)) {
-                System.exit(ZERO);
-            } else if (YES.equalsIgnoreCase(input)) {
-                System.out.println(BallerinaCDSProjectConstants.PrintStrings.OVERWRITING_EXISTING_TEMPLATES);
-            } else {
-                System.out.println(BallerinaCDSProjectConstants.PrintStrings.INVALID_INPUT);
-                System.exit(ZERO);
+        // Determine package path based on minimal flag
+        String packagePath;
+        if (ballerinaCDSProjectToolConfig.isMinimal()) {
+            // Generate directly in target directory without subfolder
+            packagePath = this.getTargetDir();
+        } else {
+            // Generate in subfolder (existing behavior)
+            packagePath = this.getTargetDir() + ballerinaCDSProjectToolConfig.getMetadataConfig().getNamePrefix() + File.separator;
+
+            // Provide option to check and overwrite the existing package
+            Console console = System.console();
+            if (console != null && Files.exists(Paths.get(packagePath))) {
+                String input = console.readLine(CMD_MESSAGE_OVERRIDE_OUTPUT_DIRECTORY);
+                if (NO.equalsIgnoreCase(input)) {
+                    System.exit(ZERO);
+                } else if (YES.equalsIgnoreCase(input)) {
+                    System.out.println(BallerinaCDSProjectConstants.PrintStrings.OVERWRITING_EXISTING_TEMPLATES);
+                } else {
+                    System.out.println(BallerinaCDSProjectConstants.PrintStrings.INVALID_INPUT);
+                    System.exit(ZERO);
+                }
             }
         }
 
@@ -83,14 +92,15 @@ public class BallerinaCDSProjectGenerator extends AbstractFHIRTemplateGenerator 
         ServiceGenerator balServiceGenerator = new ServiceGenerator(packagePath);
         balServiceGenerator.generate(toolContext, generatorProperties);
 
-        TomlGenerator tomlGenerator = new TomlGenerator(packagePath);
-        tomlGenerator.generate(toolContext, generatorProperties);
+        // Only generate TOML and meta files if not in minimal mode
+        if (!ballerinaCDSProjectToolConfig.isMinimal()) {
+            TomlGenerator tomlGenerator = new TomlGenerator(packagePath);
+            tomlGenerator.generate(toolContext, generatorProperties);
 
-        MetaGenerator metaGenerator = new MetaGenerator(packagePath);
-        metaGenerator.generate(toolContext, generatorProperties);
-
+            MetaGenerator metaGenerator = new MetaGenerator(packagePath);
+            metaGenerator.generate(toolContext, generatorProperties);
+        }
     }
-
     private BallerinaService populateServiceObject(Map<String, Object> generatorProperties) {
         BallerinaService ballerinaService = new BallerinaService();
         BallerinaCDSProjectToolConfig config = (BallerinaCDSProjectToolConfig) generatorProperties.get(CONFIG);

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
@@ -52,6 +52,7 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     private final List<InteractionConfig> interactionConfigs = new ArrayList<>();
     private boolean enableAggregatedApi;
     private List<String> aggregatedApis;
+    private boolean minimalGeneration;
 
     public BallerinaProjectToolConfig() {
         this.aggregatedApis = new ArrayList<>();
@@ -78,6 +79,10 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
             if (jsonConfigObj.getAsJsonPrimitive("enableAggregatedApi") != null) {
                 this.enableAggregatedApi = jsonConfigObj
                         .getAsJsonPrimitive("enableAggregatedApi").getAsBoolean();
+            }
+            if (jsonConfigObj.getAsJsonPrimitive("minimalGeneration") != null) {
+                this.minimalGeneration = jsonConfigObj
+                        .getAsJsonPrimitive("minimalGeneration").getAsBoolean();
             }
             if (jsonConfigObj.getAsJsonArray("aggregatedApis") != null) {
                 populateAggregatedApis(jsonConfigObj.getAsJsonArray("aggregatedApis"));
@@ -111,6 +116,9 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
                 break;
             case "project.enableAggregatedApi":
                 this.enableAggregatedApi = value.getAsBoolean();
+                break;
+            case "project.minimalGeneration":
+                this.minimalGeneration = value.getAsBoolean();
                 break;
             case "project.aggregatedApis":
                 this.aggregatedApis.clear();
@@ -224,4 +232,6 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     public List<String> getAggregatedApis() {
         return aggregatedApis;
     }
+
+    public boolean isMinimalGeneration() { return minimalGeneration;}
 }

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
@@ -117,33 +117,45 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
                 projectProperties.put("servicePackageImportIdentifier", servicePackage.substring(servicePackage.lastIndexOf(".") + 1));
                 projectProperties.put("igPackageImportIdentifier", igPackage.substring(igPackage.lastIndexOf(".") + 1));
                 projectProperties.put("dependentPackageImportIdentifier", dependentPackage.substring(dependentPackage.lastIndexOf(".") + 1));
-                projectProperties.put("projectAPIPath", this.getTargetDir() + "fhir-service");
+
+                // Use minimal generation flag to determine path
+                if (ballerinaProjectToolConfig.isMinimalGeneration()) {
+                    projectProperties.put("projectAPIPath", this.getTargetDir());
+                } else {
+                    projectProperties.put("projectAPIPath", this.getTargetDir() + "fhir-service");
+                }
 
                 AggregatedServiceGenerator aggregatedServiceGenerator = new AggregatedServiceGenerator(this.getTargetDir());
                 aggregatedServiceGenerator.generate(toolContext, projectProperties);
 
                 // Generate other files for the aggregated service
-                TomlGenerator tomlGenerator = new TomlGenerator(this.getTargetDir());
-                tomlGenerator.generate(toolContext, projectProperties);
+                // Skip Toml generation in minimal mode
+                if (!ballerinaProjectToolConfig.isMinimalGeneration()) {
+                    TomlGenerator tomlGenerator = new TomlGenerator(this.getTargetDir());
+                    tomlGenerator.generate(toolContext, projectProperties);
+                }
 
                 MetaGenerator metaGenerator = new MetaGenerator(this.getTargetDir());
                 metaGenerator.generate(toolContext, projectProperties);
 
-                // Generate OAS files for each service
-                Set<String> resourceTypes = new HashSet<>();
-                Set<BallerinaService> services = new HashSet<>();
-                for (BallerinaService service : entry.getValue().getServices().values()) {
-                    services.add(service);
-                    resourceTypes.add(service.getName());
-                }
-                projectProperties.put("resourceTypes", resourceTypes);
-                projectProperties.put("services", services);
-                OasGenerator oasGenerator = new OasGenerator(this.getTargetDir());
-                oasGenerator.generate(toolContext, projectProperties);
+                // Skip OAS and Component YAML generation in minimal mode
+                if (!ballerinaProjectToolConfig.isMinimalGeneration()) {
+                    // Generate OAS files for each service
+                    Set<String> resourceTypes = new HashSet<>();
+                    Set<BallerinaService> services = new HashSet<>();
+                    for (BallerinaService service : entry.getValue().getServices().values()) {
+                        services.add(service);
+                        resourceTypes.add(service.getName());
+                    }
+                    projectProperties.put("resourceTypes", resourceTypes);
+                    projectProperties.put("services", services);
+                    OasGenerator oasGenerator = new OasGenerator(this.getTargetDir());
+                    oasGenerator.generate(toolContext, projectProperties);
 
-                // Generate component.yaml with all endpoints (called only once)
-                ComponentYamlGenerator componentYamlGenerator = new ComponentYamlGenerator(this.getTargetDir());
-                componentYamlGenerator.generate(toolContext, projectProperties);
+                    // Generate component.yaml with all endpoints (called only once)
+                    ComponentYamlGenerator componentYamlGenerator = new ComponentYamlGenerator(this.getTargetDir());
+                    componentYamlGenerator.generate(toolContext, projectProperties);
+                }
             }
         }
     }

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/MetaGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/MetaGenerator.java
@@ -59,9 +59,13 @@ public class MetaGenerator extends AbstractFHIRTemplateGenerator {
                     "Module.md");
         }
 
-        this.getTemplateEngine().generateOutputAsFile(BallerinaProjectConstants.RESOURCE_PATH_TEMPLATES +
-                BallerinaProjectConstants.RESOURCE_PATH_SEPERATOR + "gitignore.vm", createTemplateContextForMeta(generatorProperties), directoryPath,
-                ".gitignore");
+        // Only generate .gitignore if not in minimal generation mode
+        if (!toolConfig.isMinimalGeneration()) {
+            this.getTemplateEngine().generateOutputAsFile(BallerinaProjectConstants.RESOURCE_PATH_TEMPLATES +
+                            BallerinaProjectConstants.RESOURCE_PATH_SEPERATOR + "gitignore.vm", createTemplateContextForMeta(generatorProperties), directoryPath,
+                    ".gitignore");
+        }
+
         if (generatorProperties.containsKey("aggregatedService")) {
             AggregatedService aggregatedService = (AggregatedService) generatorProperties.get("aggregatedService");
             for (BallerinaService service : aggregatedService.getServices().values()) {
@@ -69,7 +73,7 @@ public class MetaGenerator extends AbstractFHIRTemplateGenerator {
                 generatorProperties.put("resourceType", service.getName());
                 generatorProperties.put("isAggregated", true);
                 this.getTemplateEngine().generateOutputAsFile(BallerinaProjectConstants.RESOURCE_PATH_TEMPLATES +
-                        BallerinaProjectConstants.RESOURCE_PATH_SEPERATOR + "apiConfig.vm", createTemplateContextForMeta(generatorProperties), directoryPath,
+                                BallerinaProjectConstants.RESOURCE_PATH_SEPERATOR + "apiConfig.vm", createTemplateContextForMeta(generatorProperties), directoryPath,
                         service.getName().toLowerCase() + "_api_config.bal");
             }
         } else {

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/cds/CdsSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/cds/CdsSubCmd.java
@@ -27,7 +27,6 @@ import io.ballerina.health.cmd.handler.Handler;
 import io.ballerina.health.cmd.handler.HandlerFactory;
 import org.apache.commons.lang.StringUtils;
 import picocli.CommandLine;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -65,6 +64,8 @@ import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.CMD_OPTION_P
 import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.CMD_OPTION_PACKAGE_VERSION;
 import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.CMD_OPTION_PACKAGE_VERSION_DESCRIPTION;
 import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.USER_DIR;
+import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.CMD_OPTION_MINIMAL;
+import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.CMD_OPTION_MINIMAL_DESCRIPTION;
 
 
 @CommandLine.Command(name = CDS, description = CDS_SUB_TOOL_DESCRIPTION)
@@ -96,6 +97,9 @@ public class CdsSubCmd implements BLauncherCmd {
 
     @CommandLine.Option(names = {CMD_OPTION_INPUT, CMD_OPTION_INPUT_SHORTER}, description = CMD_OPTION_PACKAGE_VERSION_DESCRIPTION)
     private String inputFilePath;
+
+    @CommandLine.Option(names = {CMD_OPTION_MINIMAL}, description = CMD_OPTION_MINIMAL_DESCRIPTION)
+    private boolean minimal;
 
     @CommandLine.Parameters(description = CMD_OPTION_CUSTOM_ARGS_DESCRIPTION)
     private List<String> argList;
@@ -194,6 +198,7 @@ public class CdsSubCmd implements BLauncherCmd {
         argsMap.put(CMD_OPTION_PACKAGE_NAME, packageName);
         argsMap.put(CMD_OPTION_ORG_NAME, orgName);
         argsMap.put(CMD_OPTION_PACKAGE_VERSION, packageVersion);
+        argsMap.put(CMD_OPTION_MINIMAL, minimal);
         getTargetOutputPath();
 
         //spec path is the last argument

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
@@ -75,6 +75,8 @@ public class HealthCmdConstants {
     public static final String CMD_OPTION_INPUT_SHORTER = "-i";
     public static final String CMD_OPTION_CUSTOM_ARGS_DESCRIPTION = "Custom arguments";
     public static final String CMD_CONNECTOR = "connector";
+    public static final String CMD_OPTION_MINIMAL = "--minimal";
+    public static final String CMD_OPTION_MINIMAL_DESCRIPTION = "Generate templates without package structure and metadata files";
 
 
     public class PrintStrings {

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -96,6 +96,9 @@ public class FhirSubCmd implements BLauncherCmd {
     @CommandLine.Option(names = "--resources", description = "Comma-separated list of FHIR resources to include. If not specified, all available resources will be included")
     private String resources;
 
+    @CommandLine.Option(names = "--minimal", description = "Enable minimal generation mode to skip .choreo folder, OAS files, .gitignore, and Ballerina.toml. Only generates core service files")
+    private boolean minimal;
+
 
     @CommandLine.Parameters(description = "Custom arguments")
     private List<String> argList;
@@ -234,6 +237,7 @@ public class FhirSubCmd implements BLauncherCmd {
         argsMap.put("--dependent-ig", dependentIgs);
         argsMap.put("--aggregate", aggregate);
         argsMap.put("--resources", resources);
+        argsMap.put("--minimal", minimal);
         getTargetOutputPath();
 
         if (CMD_MODE_CONNECTOR.equals(mode)) {

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/CrdTemplateGenHandler.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/CrdTemplateGenHandler.java
@@ -47,6 +47,7 @@ import java.util.Set;
 
 import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.*;
 import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.PrintStrings.CDS_HOOKS_VALIDATION;
+import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.CMD_OPTION_MINIMAL;
 import static io.ballerina.health.cmd.core.utils.HealthCmdUtils.exitError;
 import static io.ballerina.health.cmd.core.utils.HealthCmdUtils.parseTomlToJson;
 
@@ -61,6 +62,7 @@ public class CrdTemplateGenHandler implements Handler {
     private JsonObject configJson;
     private InputStream cdsHooksJsonSchemaStream;
     private PrintStream printStream;
+    private boolean minimal;
 
     @Override
     public void init(PrintStream printStream, String cdsToolConfigFilePath) {
@@ -81,6 +83,7 @@ public class CrdTemplateGenHandler implements Handler {
         this.packageName = (String) argsMap.get(CMD_OPTION_PACKAGE_NAME);
         this.orgName = (String) argsMap.get(CMD_OPTION_ORG_NAME);
         this.packageVersion = (String) argsMap.get(CMD_OPTION_PACKAGE_VERSION);
+        this.minimal = argsMap.get(CMD_OPTION_MINIMAL) != null && (boolean) argsMap.get(CMD_OPTION_MINIMAL);
     }
 
     @Override
@@ -128,6 +131,10 @@ public class CrdTemplateGenHandler implements Handler {
                 if (packageName != null && !packageName.isEmpty()) {
                     JsonElement overrideConfig = new Gson().toJsonTree(packageName.toLowerCase());
                     toolConfigInstance.overrideConfig(PROJECT_PACKAGE_NAME_PREFIX, overrideConfig);
+                }
+                if (minimal) {
+                    JsonElement overrideConfig = new Gson().toJsonTree(minimal);
+                    toolConfigInstance.overrideConfig("project.minimal", overrideConfig);
                 }
 
                 Class<?> toolClazz = classLoader.loadClass(CDS_TOOL_CLASS_NAME);

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
@@ -54,6 +54,7 @@ public class FhirTemplateGenHandler implements Handler {
     private String[] excludedProfiles;
     private boolean aggregate;
     private String resources;
+    private boolean minimal;
 
     private JsonObject configJson;
     private PrintStream printStream;
@@ -85,6 +86,7 @@ public class FhirTemplateGenHandler implements Handler {
         this.includedProfiles = (String[]) argsMap.get("--included-profile");
         this.excludedProfiles = (String[]) argsMap.get("--excluded-profile");
         this.aggregate = (Boolean) argsMap.get("--aggregate");
+        this.minimal = (Boolean) argsMap.get("--minimal");
         this.resources = (String) argsMap.get("--resources");
     }
 
@@ -164,6 +166,11 @@ public class FhirTemplateGenHandler implements Handler {
                         }
                         toolConfigInstance.overrideConfig("project.aggregatedApis", resourcesArray);
                     }
+                }
+                // Configure minimal generation settings
+                if (minimal) {
+                    JsonElement minimalConfig = new Gson().toJsonTree(true);
+                    toolConfigInstance.overrideConfig("project.minimalGeneration", minimalConfig);
                 }
 
                 Object toolFactory = toolClass.getConstructor().newInstance();

--- a/native/health-cli/src/main/resources/ballerina-health.help
+++ b/native/health-cli/src/main/resources/ballerina-health.help
@@ -106,6 +106,15 @@ COMMANDS
                         list of FHIR resources to include in the aggregated service. If not specified,
                         all available resources will be included. Example: Patient,Observation,Encounter
 
+                    --minimal
+                        Only applicable in 'template' mode. Enable minimal generation mode to generate
+                        only the core service files without additional Choreo-specific files. When enabled,
+                        skips generation of .choreo folder, OAS definition files, .gitignore, and
+                        Ballerina.toml. Also generates files directly without the 'fhir-service'
+                        subfolder in aggregate mode.
+
+                    -c, --config <config-file-path>
+
                     -c, --config <config-file-path>
                     	This is a MANDATORY input applicable in ‘connector’ mode. Provide the path
                     	for the configuration json file containing the necessary parameters to run the

--- a/native/health-cli/src/main/resources/ballerina-health.help
+++ b/native/health-cli/src/main/resources/ballerina-health.help
@@ -107,11 +107,9 @@ COMMANDS
                         all available resources will be included. Example: Patient,Observation,Encounter
 
                     --minimal
-                        Only applicable in 'template' mode. Enable minimal generation mode to generate
-                        only the core service files without additional Choreo-specific files. When enabled,
-                        skips generation of .choreo folder, OAS definition files, .gitignore, and
-                        Ballerina.toml. Also generates files directly without the 'fhir-service'
-                        subfolder in aggregate mode.
+                        Only applicable in 'template' mode. This flag is intended only to be used by
+                        the Health Tool MCP to generate only the core service files without
+                        additional metadata or project structure files.
 
                     -c, --config <config-file-path>
 

--- a/native/health-cli/src/main/resources/ballerina-health.help
+++ b/native/health-cli/src/main/resources/ballerina-health.help
@@ -112,8 +112,6 @@ COMMANDS
                         additional metadata or project structure files.
 
                     -c, --config <config-file-path>
-
-                    -c, --config <config-file-path>
                     	This is a MANDATORY input applicable in ‘connector’ mode. Provide the path
                     	for the configuration json file containing the necessary parameters to run the
                     	tool in connector mode including Capability Statement URL of the FHIR server.

--- a/native/health-cli/src/main/resources/tool-config.json
+++ b/native/health-cli/src/main/resources/tool-config.json
@@ -70,6 +70,7 @@
           },
           "dependencies": [],
           "enableAggregatedApi": false,
+          "minimalGeneration": false,
           "aggregatedApis": [
           ],
           "builtIn": {


### PR DESCRIPTION
## Purpose
> Introduce a `--minimal` CLI option to support generating only the essential service files without the full package structure and metadata.

## Goals
> Allow agents and users to generate lightweight templates with only core service files

## Approach
>- Added a `--minimal` CLI option to both `FhirSubCmd` and `CdsSubCmd`
>- Propagated the flag through the handler layer (`FhirTemplateGenHandler`, `CrdTemplateGenHandler`) to the tool config (`BallerinaProjectToolConfig`, `BallerinaCDSProjectToolConfig`)
>- Conditionally skipped generation of Ballerina.toml, .gitignore, .choreo folder, OAS definitions, and component.yaml based on the flag
>- Updated the help file and tool-config.json to reflect the new option


## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request adds a new --minimal option to the FHIR and CDS template generation commands and wires the flag through the CLI, handlers, configuration, and generators so templates can be produced with only essential service files while omitting package structure and metadata.

Changes
- CLI: Added --minimal to FhirSubCmd and CdsSubCmd and updated the CLI help text and command constants.
- Configuration: Introduced minimal/minimalGeneration flags in BallerinaCDSProjectToolConfig and BallerinaProjectToolConfig, added PROJECT_MINIMAL and MINIMAL constants, and added minimalGeneration to tool-config.json.
- Handlers: FhirTemplateGenHandler and CrdTemplateGenHandler capture the minimal flag from CLI args and apply corresponding overrides to tool configuration.
- Generators: BallerinaProjectGenerator and BallerinaCDSProjectGenerator adjust output paths in minimal mode (omit metadata-name subfolders) and skip generation of Ballerina.toml, .choreo folder, OAS definitions, and component.yaml while preserving service generation and existing overwrite checks.
- MetaGenerator: .gitignore generation is made conditional on non-minimal mode.
- Misc: HealthCmdConstants and help resources updated for the new option.

Impact
- Enables users to generate lightweight FHIR and CDS templates containing only core service files, reducing generated artifacts for minimal or embedded workflows.
- No automated tests, extended documentation, or release notes included in this PR.
- Secure-coding practices were followed and no secrets were committed; static security scanning (FindSecurityBugs) was not run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->