### PR TITLE
[Release Health Tool 3.3.0] Prepare for release

### DIFF
--- a/ballerina/pom.xml
+++ b/ballerina/pom.xml
@@ -25,11 +25,11 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>health-tool-ballerina</artifactId>
-    <version>3.2.1</version>
+    <version>3.3.0</version>
 
     <properties>
         <version.health.cli>${project.version}</version.health.cli>

--- a/native/cds-bal-template/pom.xml
+++ b/native/cds-bal-template/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>cds-bal-template</artifactId>
-    <version>3.2.1</version>
+    <version>3.3.0</version>
 
     <dependencies>
         <dependency>

--- a/native/fhir-to-bal-connector/pom.xml
+++ b/native/fhir-to-bal-connector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/native/fhir-to-bal-lib/pom.xml
+++ b/native/fhir-to-bal-lib/pom.xml
@@ -25,12 +25,12 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>fhir-to-bal-lib</artifactId>
-    <version>3.2.1</version>
+    <version>3.3.0</version>
 
     <dependencies>
         <dependency>

--- a/native/fhir-to-bal-template/pom.xml
+++ b/native/fhir-to-bal-template/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>fhir-to-bal-template</artifactId>
-    <version>3.2.1</version>
+    <version>3.3.0</version>
 
     <dependencies>
         <dependency>

--- a/native/health-cli/pom.xml
+++ b/native/health-cli/pom.xml
@@ -25,11 +25,11 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>health-cli</artifactId>
-    <version>3.2.1</version>
+    <version>3.3.0</version>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>io.ballerina</groupId>
     <artifactId>health-tools</artifactId>
-    <version>3.2.1</version>
+    <version>3.3.0</version>
 
     <packaging>pom</packaging>
     <modules>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the project version across all Maven modules from 3.2.1 to 3.3.0 to prepare for the 3.3.0 release. The version changes are applied consistently to the parent `pom.xml` and all child module `pom.xml` files to maintain proper dependency management.

## Changes

- **Root pom.xml**: Updated parent version from 3.2.1 to 3.3.0
- **Module versions**: Updated all module versions and their parent references from 3.2.1 to 3.3.0:
  - `ballerina/pom.xml`
  - `native/cds-bal-template/pom.xml`
  - `native/fhir-to-bal-connector/pom.xml`
  - `native/fhir-to-bal-lib/pom.xml`
  - `native/fhir-to-bal-template/pom.xml`
  - `native/health-cli/pom.xml`

No functional changes to build configurations, dependencies, plugins, or other project settings were made; only version identifiers were updated to align with the release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->