### PR TITLE
Add FHIR registry pointed package/template generation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ hs_err_pid*
 replay_pid*
 **/target/*
 .idea
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.mypy_cache/

--- a/README.md
+++ b/README.md
@@ -23,15 +23,19 @@
 ```
 
 ## Supported Commands
-```shell\
+```shell
 bal health fhir -m package -o output-dir spec-path
 bal health fhir -m package --package-name my.package.name -o output-dir spec-path
 bal health fhir -m template -o output-dir spec-path
+bal health fhir -m template -o output-dir
+bal health fhir -m template --ig-name hl7.fhir.us.core --ig-version 6.1.0 -o output-dir
+bal health fhir -m package --package-name my.package --ig-name hl7.fhir.us.core --ig-version 6.1.0 -o output-dir
 bal health fhir -m connector --config configuration-file-path -o output-dir
 ```
 ### Note
-- `spec-path` is the path to the FHIR specifications. (i.e. In the specified path, there should be folder/s for each 
-Implementation Guide containing the FHIR specification files.)
+- `spec-path` is optional when `--ig-name` is provided or when template mode should use the default HL7 R4 core IG (`hl7.fhir.r4.core` from [packages.fhir.org](https://packages.fhir.org), extracted under `spec/international`).
+- When `--ig-name` is set and `--ig-version` is omitted, the CLI lists published versions interactively (TTY); use `--non-interactive` in CI to pick `dist-tags.latest` automatically.
+- With a local layout, `spec-path` points to FHIR specification folders (Implementation Guide JSON files).
 
 Directory structure of the `spec-path` should be as follows.
 ```shell

--- a/ballerina/pom.xml
+++ b/ballerina/pom.xml
@@ -25,11 +25,11 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>health-tool-ballerina</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <properties>
         <version.health.cli>${project.version}</version.health.cli>

--- a/mcp/health-tool-mcp/server.py
+++ b/mcp/health-tool-mcp/server.py
@@ -458,12 +458,20 @@ def _check_bal_at_startup() -> None:
 _check_bal_at_startup()
 
 
+def _append_registry_ig_args(cmd: list, ig_name: Optional[str], ig_version: Optional[str]) -> None:
+    if ig_name and ig_name.strip():
+        cmd.extend(["--ig-name", ig_name.strip()])
+    if ig_version and ig_version.strip():
+        cmd.extend(["--ig-version", ig_version.strip()])
+
+
 @mcp.tool(
-    description="Generate a Ballerina package from FHIR IG definitions. Required: absolute path to definitions under spec/<ig_name>. If missing, install via npm and move to spec:<newline>npm --registry https://packages.simplifier.net install <ig_name><newline>Examples: US Core hl7.fhir.us.core@8.0.1, CARIN BB hl7.fhir.us.carin-bb@2.1.0, PDex hl7.fhir.us.davinci-pdex@2.1.0. Command: bal health fhir -m package --package-name <name> -o <output> <definitions_path>"
+    description="Generate a Ballerina package from FHIR IG definitions. Provide a local definitions path under spec/<ig_name>, or use --ig-name/--ig-version to download from packages.fhir.org (e.g. hl7.fhir.us.core@6.1.0). Command: bal health fhir -m package --package-name <name> [--ig-name <id> --ig-version <ver>] -o <output> [<definitions_path>]"
 )
 def fhirPackageGeneration(
-    fhir_spec_directory: Annotated[Optional[str], "Required: Absolute path to FHIR IG definitions under spec/<ig_name>."] = None,
-    ig_name: Annotated[Optional[str], "Optional: IG name (e.g., 'hl7.fhir.us.core'). Used only for package name inference."] = None,
+    fhir_spec_directory: Annotated[Optional[str], "Optional: Absolute path to FHIR IG definitions under spec/<ig_name>. Omit when using --ig-name to download from the registry."] = None,
+    ig_name: Annotated[Optional[str], "Optional: FHIR registry package id (e.g. hl7.fhir.us.core). Downloads from packages.fhir.org when no local path is given."] = None,
+    ig_version: Annotated[Optional[str], "Optional: FHIR registry package version (e.g. 6.1.0). If omitted, bal health prompts interactively in a TTY; use --non-interactive in scripts for latest."] = None,
     package_name: Annotated[Optional[str], "Optional: Name for the generated Ballerina package. If omitted, inferred from IG name."] = None,
     working_directory: Annotated[Optional[str], "Optional: Project directory. Auto-detected from path if not provided."] = None,
     org_name: Annotated[Optional[str], "Optional: Organization name"] = None,
@@ -471,17 +479,14 @@ def fhirPackageGeneration(
     """Generate a Ballerina package from a FHIR Implementation Guide.
 
         Usage:
-        - Provide absolute definitions path under your project spec folder (e.g., "/home/user/project/spec/hl7.fhir.us.core").
-        - If definitions are not available, install via npm and move to spec:
-            npm --registry https://packages.simplifier.net install <ig_name>
-            Examples:
-                - US Core: hl7.fhir.us.core@8.0.1
-                - CARIN BB: hl7.fhir.us.carin-bb@2.1.0
-                - PDex: hl7.fhir.us.davinci-pdex@2.1.0
+        - Provide a local definitions path under spec/, or set ig_name (and optionally ig_version)
+          to download from https://packages.fhir.org into spec/ automatically.
+        - Alternative: npm --registry https://packages.simplifier.net install <ig_name>
 
     Args:
-        fhir_spec_directory: Required. Absolute path to FHIR IG definitions.
-        ig_name: Optional. IG name (e.g., "hl7.fhir.us.core", "hl7.fhir.us.carin-bb").
+        fhir_spec_directory: Optional. Absolute path to FHIR IG definitions.
+        ig_name: Optional. Registry package id (e.g. hl7.fhir.us.core).
+        ig_version: Optional. Registry package version (e.g. 6.1.0).
         package_name: Optional. Inferred from IG if omitted.
         working_directory: Optional. Auto-detected from path; if definitions path is <project>/spec/<ig-name>, uses <project>.
         org_name: Optional.
@@ -494,41 +499,39 @@ def fhirPackageGeneration(
     _caller = get_caller_identity()
     _start_time = time.time()
 
-    # Resolve inputs: require absolute definitions path under spec/<ig_name>
     setup_hint = (
-        "Place IG definitions under spec/<ig_name> and provide the absolute path.\n"
-        "If not available, install via npm and move to spec:\n"
-        "npm --registry https://packages.simplifier.net install <ig_name>\n"
-        "Examples: US Core hl7.fhir.us.core@8.0.1, CARIN BB hl7.fhir.us.carin-bb@2.1.0, PDex hl7.fhir.us.davinci-pdex@2.1.0"
-        "\nAfter moving files, provide the absolute path to the definitions again to generate the package."
-        "\nProvide user with the above instructions only keeping the message short and clear."
+        "Provide fhir_spec_directory, or set ig_name (and optionally ig_version) to download "
+        "from packages.fhir.org (e.g. hl7.fhir.us.core@6.1.0)."
     )
-    if not fhir_spec_directory:
+    use_registry_download = ig_name and ig_name.strip() and not fhir_spec_directory
+    if not fhir_spec_directory and not use_registry_download:
         return _log_output_and_return(
             tool_name="fhirPackageGeneration",
             request_id=_request_id,
             caller=_caller,
             response_str=format_error_output(
                 "fhirPackageGeneration",
-                "Missing definitions path",
+                "Missing definitions path or ig_name",
                 setup_hint
             ),
             start_time=_start_time,
         )
-    fhir_spec_directory = normalize_path(fhir_spec_directory)
+    if fhir_spec_directory:
+        fhir_spec_directory = normalize_path(fhir_spec_directory)
 
-    ws_err = _validate_within_workspace(fhir_spec_directory, "fhir_spec_directory")
-    if ws_err:
-        return _log_output_and_return(
-            tool_name="fhirPackageGeneration",
-            request_id=_request_id,
-            caller=_caller,
-            response_str=format_error_output("fhirPackageGeneration", "Validation error", ws_err),
-            start_time=_start_time,
-        )
+    if fhir_spec_directory:
+        ws_err = _validate_within_workspace(fhir_spec_directory, "fhir_spec_directory")
+        if ws_err:
+            return _log_output_and_return(
+                tool_name="fhirPackageGeneration",
+                request_id=_request_id,
+                caller=_caller,
+                response_str=format_error_output("fhirPackageGeneration", "Validation error", ws_err),
+                start_time=_start_time,
+            )
 
     # If definitions path doesn't exist, return concise setup guidance
-    if not os.path.exists(fhir_spec_directory):
+    if fhir_spec_directory and not os.path.exists(fhir_spec_directory):
         return _log_output_and_return(
             tool_name="fhirPackageGeneration",
             request_id=_request_id,
@@ -541,7 +544,7 @@ def fhirPackageGeneration(
             start_time=_start_time,
         )
     
-    if not os.path.isdir(fhir_spec_directory):
+    if fhir_spec_directory and not os.path.isdir(fhir_spec_directory):
         return _log_output_and_return(
             tool_name="fhirPackageGeneration",
             request_id=_request_id,
@@ -554,44 +557,55 @@ def fhirPackageGeneration(
             start_time=_start_time,
         )
     
-    # Check if directory contains files (not empty)
-    try:
-        files = os.listdir(fhir_spec_directory)
-        actual_files = [f for f in files if not f.startswith('.')]
-        if not actual_files:
+    if use_registry_download:
+        if not working_directory:
             return _log_output_and_return(
                 tool_name="fhirPackageGeneration",
                 request_id=_request_id,
                 caller=_caller,
                 response_str=format_error_output(
                     "fhirPackageGeneration",
-                    "Empty directory",
-                    f"Empty definitions at: {fhir_spec_directory}. {setup_hint}"
+                    "Validation error",
+                    "working_directory is required when downloading an IG via ig_name.",
                 ),
                 start_time=_start_time,
             )
-    except Exception as e:
-        return _log_output_and_return(
-            tool_name="fhirPackageGeneration",
-            request_id=_request_id,
-            caller=_caller,
-            response_str=format_error_output("fhirPackageGeneration", "Directory error", f"Error reading directory {fhir_spec_directory}: {e}"),
-            start_time=_start_time,
-        )
-    
-    # Auto-detect working_directory if not provided
-    if not working_directory:
-        # If path is like <project>/spec/<ig-name>, use <project> as working directory
-        path_parts = fhir_spec_directory.split(os.sep)
-        if 'spec' in path_parts:
-            spec_index = len(path_parts) - 1 - path_parts[::-1].index('spec')
-            working_directory = os.sep.join(path_parts[:spec_index])
-        else:
-            # Fallback: use parent directory
-            working_directory = os.path.dirname(fhir_spec_directory)
-    
-    # Normalize working directory
-    working_directory = normalize_path(working_directory)
+        working_directory = normalize_path(working_directory)
+    else:
+        try:
+            files = os.listdir(fhir_spec_directory)
+            actual_files = [f for f in files if not f.startswith('.')]
+            if not actual_files:
+                return _log_output_and_return(
+                    tool_name="fhirPackageGeneration",
+                    request_id=_request_id,
+                    caller=_caller,
+                    response_str=format_error_output(
+                        "fhirPackageGeneration",
+                        "Empty directory",
+                        f"Empty definitions at: {fhir_spec_directory}. {setup_hint}"
+                    ),
+                    start_time=_start_time,
+                )
+        except Exception as e:
+            return _log_output_and_return(
+                tool_name="fhirPackageGeneration",
+                request_id=_request_id,
+                caller=_caller,
+                response_str=format_error_output("fhirPackageGeneration", "Directory error", f"Error reading directory {fhir_spec_directory}: {e}"),
+                start_time=_start_time,
+            )
+
+        # Auto-detect working_directory if not provided
+        if not working_directory:
+            path_parts = fhir_spec_directory.split(os.sep)
+            if 'spec' in path_parts:
+                spec_index = len(path_parts) - 1 - path_parts[::-1].index('spec')
+                working_directory = os.sep.join(path_parts[:spec_index])
+            else:
+                working_directory = os.path.dirname(fhir_spec_directory)
+
+        working_directory = normalize_path(working_directory)
 
     ws_err = _validate_within_workspace(working_directory, "working_directory")
     if ws_err:
@@ -615,7 +629,7 @@ def fhirPackageGeneration(
 
     # Infer package name if not provided
     if not package_name or not package_name.strip():
-        base_candidate = ig_name or os.path.basename(fhir_spec_directory.rstrip('/\\'))
+        base_candidate = ig_name or (os.path.basename(fhir_spec_directory.rstrip('/\\')) if fhir_spec_directory else "")
         base = (base_candidate or "").lower()
         try:
             if "hl7.fhir.us.core" in base:
@@ -694,8 +708,11 @@ def fhirPackageGeneration(
     # Add optional organization name
     if org_name:
         cmd.extend(["--org-name", org_name])
-    
-    cmd.append(fhir_spec_directory)
+
+    _append_registry_ig_args(cmd, ig_name, ig_version)
+
+    if fhir_spec_directory:
+        cmd.append(fhir_spec_directory)
 
     disk_err = _check_disk_space(output_location, "fhirPackageGeneration", _request_id, _caller, _start_time)
     if disk_err:
@@ -761,11 +778,13 @@ def fhirPackageGeneration(
         )
 
 @mcp.tool(
-    description="Generate FHIR API templates from a FHIR Implementation Guide. Required: absolute path to definitions under spec/<ig_name>. If missing, install via npm and move to spec:<newline>npm --registry https://packages.simplifier.net install <ig_name><newline>Examples: US Core hl7.fhir.us.core@8.0.1, CARIN BB hl7.fhir.us.carin-bb@2.1.0, PDex hl7.fhir.us.davinci-pdex@2.1.0. Command: bal health fhir -m template --dependent-package <package> [--included-profile <url>]* [--excluded-profile <url>]* -o <output> <definitions_path>"
+    description="Generate FHIR API templates from a FHIR Implementation Guide. Use a local definitions path, --ig-name/--ig-version to download from packages.fhir.org, or omit both to use default hl7.fhir.r4.core. Command: bal health fhir -m template [--dependent-package <pkg>] [--ig-name <id> --ig-version <ver>] -o <output> [<definitions_path>]"
 )
 def fhirTemplateGeneration(
-    dependent_package: Annotated[str, "REQUIRED: Fully qualified Ballerina package (e.g., 'ballerinax/health.fhir.r4.uscore501', 'ballerinax/health.fhir.r4international401')"],
-    fhir_spec_directory: Annotated[str, "REQUIRED: Absolute path to FHIR IG definitions under spec/<ig_name>."] ,
+    dependent_package: Annotated[Optional[str], "Optional: Ballerina package (e.g. ballerinax/health.fhir.r4.uscore501). Inferred for known IGs or default R4 core."] = None,
+    fhir_spec_directory: Annotated[Optional[str], "Optional: Absolute path to FHIR IG definitions. Omit to download via ig_name or default hl7.fhir.r4.core."] = None,
+    ig_name: Annotated[Optional[str], "Optional: FHIR registry package id (e.g. hl7.fhir.us.core)."] = None,
+    ig_version: Annotated[Optional[str], "Optional: FHIR registry package version (e.g. 6.1.0). If omitted, bal health prompts interactively in a TTY; use --non-interactive in scripts for latest."] = None,
     working_directory: Annotated[Optional[str], "Optional: Project directory. Auto-detected from path if not provided."] = None,
     org_name: Annotated[Optional[str], "Optional: Organization name for generated templates"] = None,
     included_profiles: Annotated[Optional[list[str]], "Optional: FHIR profile URLs to ONLY include. Reduces generation time by skipping unwanted profiles."] = None,
@@ -776,17 +795,13 @@ def fhirTemplateGeneration(
     This tool generates Ballerina service templates based on FHIR profiles in an IG.
     Equivalent to: bal health fhir -m template -o <output> --org-name <org> --dependent-package <package> <definitions_path>
 
-    IMPORTANT: Both fhir_spec_directory (absolute definitions path) AND dependent_package are REQUIRED.
-    If definitions are not available locally, install via npm and move to spec:
-        npm --registry https://packages.simplifier.net install <ig_name>
-        Examples:
-            - US Core: hl7.fhir.us.core@8.0.1
-            - CARIN BB: hl7.fhir.us.carin-bb@2.1.0
-            - PDex: hl7.fhir.us.davinci-pdex@2.1.0
+    Provide a local path, ig_name/ig_version for registry download, or neither for default HL7 R4 core templates.
 
     Args:
-        fhir_spec_directory: Required. Absolute path to FHIR IG definitions under spec/<ig_name>.
-        dependent_package: Required. Fully qualified Ballerina package name (e.g., 'ballerinax/health.fhir.r4.uscore501').
+        fhir_spec_directory: Optional. Absolute path to FHIR IG definitions.
+        dependent_package: Optional. Fully qualified Ballerina package name.
+        ig_name: Optional. Registry package id.
+        ig_version: Optional. Registry package version.
         working_directory: Optional. Auto-detected from path; if definitions path is <project>/spec/<ig-name>, uses <project>.
         org_name: Optional. Organization name for generated templates (e.g., 'healthcare_samples').
         included_profiles: Optional. List of FHIR profile URLs to ONLY include in generation.
@@ -802,26 +817,11 @@ def fhirTemplateGeneration(
 
     # Resolve inputs: require absolute definitions path under spec/<ig_name>
     setup_hint = (
-        "Place IG definitions under spec/<ig_name> and provide the absolute path.\n"
-        "If not available, install via npm and move to spec:\n"
-        "npm --registry https://packages.simplifier.net install <ig_name>\n"
-        "Examples: US Core hl7.fhir.us.core@8.0.1, CARIN BB hl7.fhir.us.carin-bb@2.1.0, PDex hl7.fhir.us.davinci-pdex@2.1.0"
-        "\nAfter moving files, provide the absolute path to the definitions again to generate the templates."
-        "\nProvide user with the above instructions only keeping the message short and clear."
+        "Provide fhir_spec_directory, ig_name/ig_version for registry download, or omit both for default R4 core."
     )
 
-    # Validate dependent package
-    if not dependent_package or not dependent_package.strip():
-        return _log_output_and_return(
-            tool_name="fhirTemplateGeneration",
-            request_id=_request_id,
-            caller=_caller,
-            response_str=format_error_output("fhirTemplateGeneration", "Validation error", "dependent_package is required (e.g., ballerinax/health.fhir.r4.uscore501)"),
-            start_time=_start_time,
-        )
-
-    # Validate required spec path
-    if not fhir_spec_directory:
+    use_registry_download = (ig_name and ig_name.strip()) or not fhir_spec_directory
+    if not fhir_spec_directory and not use_registry_download:
         return _log_output_and_return(
             tool_name="fhirTemplateGeneration",
             request_id=_request_id,
@@ -834,9 +834,11 @@ def fhirTemplateGeneration(
             start_time=_start_time,
         )
 
-    fhir_spec_directory = normalize_path(fhir_spec_directory)
+    if fhir_spec_directory:
+        fhir_spec_directory = normalize_path(fhir_spec_directory)
 
-    ws_err = _validate_within_workspace(fhir_spec_directory, "fhir_spec_directory")
+    if fhir_spec_directory:
+        ws_err = _validate_within_workspace(fhir_spec_directory, "fhir_spec_directory")
     if ws_err:
         return _log_output_and_return(
             tool_name="fhirTemplateGeneration",
@@ -846,8 +848,7 @@ def fhirTemplateGeneration(
             start_time=_start_time,
         )
 
-    # If definitions path doesn't exist, return concise setup guidance
-    if not os.path.exists(fhir_spec_directory):
+    if fhir_spec_directory and not os.path.exists(fhir_spec_directory):
         return _log_output_and_return(
             tool_name="fhirTemplateGeneration",
             request_id=_request_id,
@@ -860,7 +861,56 @@ def fhirTemplateGeneration(
             start_time=_start_time,
         )
 
-    if not os.path.isdir(fhir_spec_directory):
+    if fhir_spec_directory:
+        if not os.path.isdir(fhir_spec_directory):
+            return _log_output_and_return(
+                tool_name="fhirTemplateGeneration",
+                request_id=_request_id,
+                caller=_caller,
+                response_str=format_error_output(
+                    "fhirTemplateGeneration",
+                    "Validation error",
+                    f"Not a directory: {fhir_spec_directory}. {setup_hint}",
+                ),
+                start_time=_start_time,
+            )
+
+        try:
+            files = os.listdir(fhir_spec_directory)
+            actual_files = [f for f in files if not f.startswith('.')]
+            if not actual_files:
+                return _log_output_and_return(
+                    tool_name="fhirTemplateGeneration",
+                    request_id=_request_id,
+                    caller=_caller,
+                    response_str=format_error_output(
+                        "fhirTemplateGeneration",
+                        "Empty directory",
+                        f"Empty definitions at: {fhir_spec_directory}. {setup_hint}",
+                    ),
+                    start_time=_start_time,
+                )
+        except Exception as e:
+            return _log_output_and_return(
+                tool_name="fhirTemplateGeneration",
+                request_id=_request_id,
+                caller=_caller,
+                response_str=format_error_output(
+                    "fhirTemplateGeneration",
+                    "Directory error",
+                    f"Error reading directory {fhir_spec_directory}: {e}",
+                ),
+                start_time=_start_time,
+            )
+
+        if not working_directory:
+            path_parts = fhir_spec_directory.split(os.sep)
+            if 'spec' in path_parts:
+                spec_index = len(path_parts) - 1 - path_parts[::-1].index('spec')
+                working_directory = os.sep.join(path_parts[:spec_index])
+            else:
+                working_directory = os.path.dirname(fhir_spec_directory)
+    elif not working_directory:
         return _log_output_and_return(
             tool_name="fhirTemplateGeneration",
             request_id=_request_id,
@@ -868,52 +918,11 @@ def fhirTemplateGeneration(
             response_str=format_error_output(
                 "fhirTemplateGeneration",
                 "Validation error",
-                f"Not a directory: {fhir_spec_directory}. {setup_hint}",
+                "working_directory is required when using registry download without a local definitions path.",
             ),
             start_time=_start_time,
         )
 
-    # Check if directory contains files (not empty)
-    try:
-        files = os.listdir(fhir_spec_directory)
-        actual_files = [f for f in files if not f.startswith('.')]
-        if not actual_files:
-            return _log_output_and_return(
-                tool_name="fhirTemplateGeneration",
-                request_id=_request_id,
-                caller=_caller,
-                response_str=format_error_output(
-                    "fhirTemplateGeneration",
-                    "Empty directory",
-                    f"Empty definitions at: {fhir_spec_directory}. {setup_hint}",
-                ),
-                start_time=_start_time,
-            )
-    except Exception as e:
-        return _log_output_and_return(
-            tool_name="fhirTemplateGeneration",
-            request_id=_request_id,
-            caller=_caller,
-            response_str=format_error_output(
-                "fhirTemplateGeneration",
-                "Directory error",
-                f"Error reading directory {fhir_spec_directory}: {e}",
-            ),
-            start_time=_start_time,
-        )
-
-    # Auto-detect working_directory if not provided
-    if not working_directory:
-        # If path is like <project>/spec/<ig-name>, use <project> as working directory
-        path_parts = fhir_spec_directory.split(os.sep)
-        if 'spec' in path_parts:
-            spec_index = len(path_parts) - 1 - path_parts[::-1].index('spec')
-            working_directory = os.sep.join(path_parts[:spec_index])
-        else:
-            # Fallback: use parent directory
-            working_directory = os.path.dirname(fhir_spec_directory)
-
-    # Normalize working directory
     working_directory = normalize_path(working_directory)
 
     ws_err = _validate_within_workspace(working_directory, "working_directory")
@@ -1003,15 +1012,17 @@ def fhirTemplateGeneration(
     cmd = [
         bal_exe, "health", "fhir",
         "--mode", "template",
-        "--dependent-package", dependent_package,
     ]
 
-    # Output location (always set, defaulted above)
+    if dependent_package and dependent_package.strip():
+        cmd.extend(["--dependent-package", dependent_package.strip()])
+
     cmd.extend(["--output", output_location])
 
-    # Add optional organization name
     if org_name:
         cmd.extend(["--org-name", org_name])
+
+    _append_registry_ig_args(cmd, ig_name, ig_version)
 
     # Add included profiles (can be specified multiple times)
     if included_profiles:
@@ -1022,8 +1033,9 @@ def fhirTemplateGeneration(
     if excluded_profiles:
         for profile in excluded_profiles:
             cmd.extend(["--excluded-profile", profile])
-    cmd.extend(["--aggregate","--minimal"])
-    cmd.append(fhir_spec_directory)
+    cmd.extend(["--aggregate", "--minimal"])
+    if fhir_spec_directory:
+        cmd.append(fhir_spec_directory)
 
     disk_err = _check_disk_space(output_location, "fhirTemplateGeneration", _request_id, _caller, _start_time)
     if disk_err:

--- a/native/cds-bal-template/pom.xml
+++ b/native/cds-bal-template/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>cds-bal-template</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <dependencies>
         <dependency>

--- a/native/fhir-to-bal-connector/pom.xml
+++ b/native/fhir-to-bal-connector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/native/fhir-to-bal-lib/pom.xml
+++ b/native/fhir-to-bal-lib/pom.xml
@@ -25,12 +25,12 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>fhir-to-bal-lib</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <dependencies>
         <dependency>

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r4/R4ResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r4/R4ResourceContextGenerator.java
@@ -338,20 +338,21 @@ public class R4ResourceContextGenerator extends AbstractResourceContextGenerator
         List<CanonicalType> profiles = type.getProfile();
         if (!profiles.isEmpty()) {
             for (CanonicalType profile : profiles) {
-                String profileType = CommonUtil.getSplitTokenAt(profile.getValue(), "/", ToolConstants.TokenPosition.END);
+                String profileUrl = CommonUtil.stripCanonicalVersion(profile.getValue());
+                String profileType = CommonUtil.getSplitTokenAt(profileUrl, "/", ToolConstants.TokenPosition.END);
                 profileType = GeneratorUtils.getInstance().getUniqueIdentifierFromId(profileType);
-                if (getDatatypeTemplateContextMap().containsKey(profile.getValue())) {
-                    element.addProfile(profile.getValue(), profileType);
+                if (getDatatypeTemplateContextMap().containsKey(profileUrl)) {
+                    element.addProfile(profileUrl, profileType);
                     DataTypesRegistry.getInstance().addDataType(profileType);
                 } else {
-                    element.addProfile(profile.getValue(), profileType);
+                    element.addProfile(profileUrl, profileType);
                 }
                 //check for prefix when non R4 profiles are available
                 for (String dependentIgUrl : getToolConfig().getPackageConfig().getDependentIgs().keySet()) {
-                    if (profile.getValue().startsWith(dependentIgUrl)) {
+                    if (profileUrl.startsWith(dependentIgUrl)) {
                         String dependentIgPackageName = getToolConfig().getPackageConfig().getDependentIgs().get(dependentIgUrl);
                         String dependentIgPackagePrefix = CommonUtil.getSplitTokenAt(dependentIgPackageName, "\\.", ToolConstants.TokenPosition.END);
-                        element.getProfiles().get(profile.getValue()).setPrefix(dependentIgPackagePrefix);
+                        element.getProfiles().get(profileUrl).setPrefix(dependentIgPackagePrefix);
                     }
                 }
             }

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r5/R5ResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r5/R5ResourceContextGenerator.java
@@ -360,21 +360,22 @@ public class R5ResourceContextGenerator extends AbstractResourceContextGenerator
         List<CanonicalType> profiles = type.getProfile();
         if (!profiles.isEmpty()) {
             for (CanonicalType profile : profiles) {
-                String profileType = CommonUtil.getSplitTokenAt(profile.getValue(), "/", ToolConstants.TokenPosition.END);
+                String profileUrl = CommonUtil.stripCanonicalVersion(profile.getValue());
+                String profileType = CommonUtil.getSplitTokenAt(profileUrl, "/", ToolConstants.TokenPosition.END);
                 profileType = GeneratorUtils.getInstance().getUniqueIdentifierFromId(profileType);
 
-                if (getDatatypeTemplateContextMap().containsKey(profile.getValue())) {
-                    element.addProfile(profile.getValue(), profileType);
+                if (getDatatypeTemplateContextMap().containsKey(profileUrl)) {
+                    element.addProfile(profileUrl, profileType);
                     DataTypesRegistry.getInstance().addDataType(profileType);
                 } else {
-                    element.addProfile(profile.getValue(), profileType);
+                    element.addProfile(profileUrl, profileType);
                 }
                 //check for prefix when non R5 profiles are available
                 for (String dependentIgUrl : getToolConfig().getPackageConfig().getDependentIgs().keySet()) {
-                    if (profile.getValue().startsWith(dependentIgUrl)) {
+                    if (profileUrl.startsWith(dependentIgUrl)) {
                         String dependentIgPackageName = getToolConfig().getPackageConfig().getDependentIgs().get(dependentIgUrl);
                         String dependentIgPackagePrefix = CommonUtil.getSplitTokenAt(dependentIgPackageName, "\\.", ToolConstants.TokenPosition.END);
-                        element.getProfiles().get(profile.getValue()).setPrefix(dependentIgPackagePrefix);
+                        element.getProfiles().get(profileUrl).setPrefix(dependentIgPackagePrefix);
                     }
                 }
             }

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/CommonUtil.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/CommonUtil.java
@@ -74,6 +74,17 @@ public class CommonUtil {
      * @param tokenPosition position of the preferred token
      * @return preferred token
      */
+    /**
+     * Removes the version suffix from a FHIR canonical URL ({@code url|version}).
+     */
+    public static String stripCanonicalVersion(String canonical) {
+        if (canonical == null || canonical.isEmpty()) {
+            return canonical;
+        }
+        int versionSeparator = canonical.indexOf('|');
+        return versionSeparator >= 0 ? canonical.substring(0, versionSeparator) : canonical;
+    }
+
     public static String getSplitTokenAt(String string, String delimiter, ToolConstants.TokenPosition tokenPosition) {
         String[] tokens = string.split(delimiter);
         int position = 0;

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/GeneratorUtils.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/GeneratorUtils.java
@@ -400,6 +400,7 @@ public class GeneratorUtils {
     }
 
     public String getUniqueIdentifierFromId(String id) {
+        id = CommonUtil.stripCanonicalVersion(id);
         id = id.replace("StructureDefinition", "");
         StringBuilder uniqueIdentifier = new StringBuilder();
         String[] idTokens = id.split("-");

--- a/native/fhir-to-bal-template/pom.xml
+++ b/native/fhir-to-bal-template/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>fhir-to-bal-template</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <dependencies>
         <dependency>

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/AbstractBallerinaProjectTool.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/AbstractBallerinaProjectTool.java
@@ -183,6 +183,10 @@ public abstract class AbstractBallerinaProjectTool extends AbstractFHIRTool {
         dependenciesMap.put("basePackage", fhirBaseImportStatement.toLowerCase());
         dependenciesMap.put("servicePackage", fhirServiceImportStatement.toLowerCase());
         dependenciesMap.put("dependentPackage", fhirInternationalImportStatement.toLowerCase());
+        dependenciesMap.put("useGenerateIgModule",
+                String.valueOf(getBallerinaProjectToolConfig().isGenerateIgModuleEnabled()));
+        dependenciesMap.put("generateIgModuleName",
+                getBallerinaProjectToolConfig().getGenerateIgModuleName());
     }
 
     protected abstract void populateBalService();

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
@@ -53,6 +53,9 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     private boolean enableAggregatedApi;
     private List<String> aggregatedApis;
     private boolean minimalGeneration;
+    private boolean generateIgModuleEnabled;
+    private String generateIgModuleName;
+    private String generateIgModuleSourceDir;
 
     public BallerinaProjectToolConfig() {
         this.aggregatedApis = new ArrayList<>();
@@ -86,6 +89,17 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
             }
             if (jsonConfigObj.getAsJsonArray("aggregatedApis") != null) {
                 populateAggregatedApis(jsonConfigObj.getAsJsonArray("aggregatedApis"));
+            }
+            if (jsonConfigObj.getAsJsonObject("generateIgModule") != null) {
+                JsonObject generateIgModuleConfig = jsonConfigObj.getAsJsonObject("generateIgModule");
+                if (generateIgModuleConfig.getAsJsonPrimitive("enabled") != null) {
+                    this.generateIgModuleEnabled = generateIgModuleConfig
+                            .getAsJsonPrimitive("enabled").getAsBoolean();
+                }
+                if (generateIgModuleConfig.getAsJsonPrimitive("name") != null) {
+                    this.generateIgModuleName = generateIgModuleConfig
+                            .getAsJsonPrimitive("name").getAsString();
+                }
             }
         }
         //todo: add toml type config handling
@@ -128,6 +142,15 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
                         this.aggregatedApis.add(resourcesArray.get(i).getAsString());
                     }
                 }
+                break;
+            case "project.generateIgModule.enabled":
+                this.generateIgModuleEnabled = value.getAsBoolean();
+                break;
+            case "project.generateIgModule.name":
+                this.generateIgModuleName = value.getAsString();
+                break;
+            case "project.generateIgModule.sourceDir":
+                this.generateIgModuleSourceDir = value.getAsString();
                 break;
             default:
                 LOG.warn("Invalid config path: " + jsonPath);
@@ -234,4 +257,16 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     }
 
     public boolean isMinimalGeneration() { return minimalGeneration;}
+
+    public boolean isGenerateIgModuleEnabled() {
+        return generateIgModuleEnabled;
+    }
+
+    public String getGenerateIgModuleName() {
+        return generateIgModuleName;
+    }
+
+    public String getGenerateIgModuleSourceDir() {
+        return generateIgModuleSourceDir;
+    }
 }

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
@@ -27,12 +27,15 @@ import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.AggregatedS
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.BallerinaService;
 
 import java.io.Console;
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.stream.Stream;
 
 /**
  * Generator class to wrap all the generator classes in Ballerina project generator.
@@ -53,9 +56,9 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
         //evaluate usage of ? typed map as generator properties.
 
         String packagePath = this.getTargetDir();
-        // Provide option to check and overwrite the existing package
+        // Provide option to check and overwrite existing template output (not staging dirs alone)
         Console console = System.console();
-        if (console != null && Files.exists(Paths.get(packagePath))) {
+        if (console != null && hasExistingGeneratedTemplates(packagePath, ballerinaProjectToolConfig, serviceMap)) {
             String input = console.readLine("Generated templates already exists. Do you want to overwrite? (y/n): ");
             if ("n".equalsIgnoreCase(input)) {
                 System.exit(0);
@@ -76,15 +79,24 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
                 projectProperties.put("config", ballerinaProjectToolConfig);
                 projectProperties.put("dependencies", dependenciesMap);
 
+                String projectAPIPath = this.getTargetDir() + entry.getKey().toLowerCase();
+                String templateName = ballerinaProjectToolConfig.getVersionConfig().getNamePrefix() + "." +
+                        entry.getKey().toLowerCase();
                 String basePackage = dependenciesMap.get("basePackage");
                 String servicePackage = dependenciesMap.get("servicePackage");
                 String igPackage = dependenciesMap.get("igPackage");
-                String dependentPackage = dependenciesMap.get("dependentPackage");
-                projectProperties.put("basePackageImportIdentifier", basePackage.substring(basePackage.lastIndexOf(".") + 1));
-                projectProperties.put("servicePackageImportIdentifier", servicePackage.substring(servicePackage.lastIndexOf(".") + 1));
-                projectProperties.put("igPackageImportIdentifier", igPackage.substring(igPackage.lastIndexOf(".") + 1));
-                projectProperties.put("dependentPackageImportIdentifier", dependentPackage.substring(dependentPackage.lastIndexOf(".") + 1));
-                projectProperties.put("projectAPIPath", this.getTargetDir() + entry.getKey().toLowerCase());
+                String dependentPackage = resolveDependentPackageImport(
+                        ballerinaProjectToolConfig, dependenciesMap, templateName);
+                dependenciesMap.put("dependentPackage", dependentPackage);
+                projectProperties.put("basePackageImportIdentifier", getImportIdentifier(basePackage));
+                projectProperties.put("servicePackageImportIdentifier", getImportIdentifier(servicePackage));
+                projectProperties.put("igPackageImportIdentifier", getImportIdentifier(igPackage));
+                projectProperties.put("dependentPackageImportIdentifier", getImportIdentifier(dependentPackage));
+                projectProperties.put("projectAPIPath", projectAPIPath);
+
+                if (ballerinaProjectToolConfig.isGenerateIgModuleEnabled()) {
+                    generateIgModule(projectAPIPath, ballerinaProjectToolConfig, serviceMap, null);
+                }
 
                 ServiceGenerator balServiceGenerator = new ServiceGenerator(this.getTargetDir());
                 balServiceGenerator.generate(toolContext, projectProperties);
@@ -112,17 +124,24 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
                 String basePackage = dependenciesMap.get("basePackage");
                 String servicePackage = dependenciesMap.get("servicePackage");
                 String igPackage = dependenciesMap.get("igPackage");
-                String dependentPackage = dependenciesMap.get("dependentPackage");
-                projectProperties.put("basePackageImportIdentifier", basePackage.substring(basePackage.lastIndexOf(".") + 1));
-                projectProperties.put("servicePackageImportIdentifier", servicePackage.substring(servicePackage.lastIndexOf(".") + 1));
-                projectProperties.put("igPackageImportIdentifier", igPackage.substring(igPackage.lastIndexOf(".") + 1));
-                projectProperties.put("dependentPackageImportIdentifier", dependentPackage.substring(dependentPackage.lastIndexOf(".") + 1));
+                String templateName = "FHIRServerTemplate";
+                String dependentPackage = resolveDependentPackageImport(
+                        ballerinaProjectToolConfig, dependenciesMap, templateName);
+                dependenciesMap.put("dependentPackage", dependentPackage);
+                projectProperties.put("basePackageImportIdentifier", getImportIdentifier(basePackage));
+                projectProperties.put("servicePackageImportIdentifier", getImportIdentifier(servicePackage));
+                projectProperties.put("igPackageImportIdentifier", getImportIdentifier(igPackage));
+                projectProperties.put("dependentPackageImportIdentifier", getImportIdentifier(dependentPackage));
 
                 // Use minimal generation flag to determine path
                 if (ballerinaProjectToolConfig.isMinimalGeneration()) {
                     projectProperties.put("projectAPIPath", this.getTargetDir());
                 } else {
                     projectProperties.put("projectAPIPath", this.getTargetDir() + "fhir-service");
+                }
+                if (ballerinaProjectToolConfig.isGenerateIgModuleEnabled()) {
+                    generateIgModule(projectProperties.get("projectAPIPath").toString(),
+                            ballerinaProjectToolConfig, serviceMap, entry.getValue());
                 }
 
                 AggregatedServiceGenerator aggregatedServiceGenerator = new AggregatedServiceGenerator(this.getTargetDir());
@@ -157,6 +176,93 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
                     componentYamlGenerator.generate(toolContext, projectProperties);
                 }
             }
+        }
+    }
+
+    private boolean hasExistingGeneratedTemplates(String packagePath, BallerinaProjectToolConfig config,
+                                                Map<String, BallerinaService> serviceMap) {
+        Path basePath = Paths.get(packagePath);
+        if (!Files.isDirectory(basePath)) {
+            return false;
+        }
+        if (config.isEnableAggregatedApi()) {
+            Path projectPath = config.isMinimalGeneration() ? basePath : basePath.resolve("fhir-service");
+            return Files.exists(projectPath.resolve("service.bal"));
+        }
+        if (serviceMap == null || serviceMap.isEmpty()) {
+            return false;
+        }
+        for (String resourceType : serviceMap.keySet()) {
+            if (Files.exists(basePath.resolve(resourceType.toLowerCase()).resolve("service.bal"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String resolveDependentPackageImport(BallerinaProjectToolConfig config, Map<String, String> dependenciesMap,
+                                                 String templateName) {
+        if (!config.isGenerateIgModuleEnabled()) {
+            return dependenciesMap.get("dependentPackage");
+        }
+        String igModuleName = config.getGenerateIgModuleName();
+        return templateName + "." + igModuleName;
+    }
+
+    private String getImportIdentifier(String importStatement) {
+        if (importStatement == null || importStatement.isEmpty()) {
+            return "";
+        }
+        int slashIndex = importStatement.lastIndexOf('/');
+        String modulePath = slashIndex >= 0 ? importStatement.substring(slashIndex + 1) : importStatement;
+        int dotIndex = modulePath.lastIndexOf('.');
+        return dotIndex >= 0 ? modulePath.substring(dotIndex + 1) : modulePath;
+    }
+
+    private void generateIgModule(String projectAPIPath, BallerinaProjectToolConfig config,
+                                  Map<String, BallerinaService> serviceMap,
+                                  AggregatedService aggregatedService) throws CodeGenException {
+        String igModuleName = config.getGenerateIgModuleName();
+        if (igModuleName == null || igModuleName.isEmpty()) {
+            return;
+        }
+        Path modulePath = Paths.get(projectAPIPath, "modules", igModuleName);
+        try {
+            Files.createDirectories(modulePath);
+        } catch (IOException e) {
+            throw new CodeGenException("Error creating IG module directory: " + e.getMessage(), e);
+        }
+        String generateIgModuleSourceDir = config.getGenerateIgModuleSourceDir();
+        if (generateIgModuleSourceDir == null || generateIgModuleSourceDir.isEmpty()) {
+            throw new CodeGenException("IG module source directory is not set.");
+        }
+        Path sourceDirectory = Paths.get(generateIgModuleSourceDir);
+        try {
+            try (Stream<Path> sourceFiles = Files.walk(sourceDirectory)) {
+                sourceFiles
+                        .filter(path -> !Files.isDirectory(path))
+                        .filter(path -> path.toString().endsWith(".bal")
+                                || path.toString().endsWith("Package.md")
+                                || path.toString().contains("resources" + java.io.File.separator))
+                        .forEach(path -> {
+                            Path relativePath = sourceDirectory.relativize(path);
+                            Path destination = modulePath.resolve(relativePath);
+                            try {
+                                Files.createDirectories(destination.getParent());
+                                Files.copy(path, destination, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+            }
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof IOException) {
+                throw new CodeGenException("Error generating IG module: " + e.getCause().getMessage(),
+                        e.getCause());
+            }
+            throw e;
+        } catch (IOException e) {
+            throw new CodeGenException("Error generating IG module: " + e.getMessage(), e);
         }
     }
 }

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/model/FHIRProfile.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/model/FHIRProfile.java
@@ -120,6 +120,11 @@ public class FHIRProfile<StructureDefinition> {
     }
 
     public void setPackagePrefix(BallerinaProjectToolConfig config) {
+        if (config.isGenerateIgModuleEnabled() && config.getGenerateIgModuleName() != null
+                && !config.getGenerateIgModuleName().isEmpty()) {
+            this.packagePrefix = config.getGenerateIgModuleName();
+            return;
+        }
         String igPackage = config.getVersionConfig().getDependentPackage();
         if (igPackage.contains("/")) {
             String pkgNameWithoutOrg = igPackage.split("/")[1];

--- a/native/fhir-to-bal-template/src/main/resources/template/aggregatedBalService.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/aggregatedBalService.vm
@@ -22,7 +22,7 @@
 
 import ballerina/http;
 #foreach($import in $aggregatedService.getImportsList())
-import $import.toLowerCase();
+import $import;
 #end
 
 # Generic types to wrap all implemented profiles for each resource.

--- a/native/fhir-to-bal-template/src/main/resources/template/balService.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/balService.vm
@@ -22,7 +22,7 @@
 
 import ballerina/http;
 #foreach($import in $service.getImportsList())
-import $import.toLowerCase();
+import $import;
 #end
 
 # Generic type to wrap all implemented profiles.

--- a/native/health-cli/pom.xml
+++ b/native/health-cli/pom.xml
@@ -25,11 +25,11 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>health-cli</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <dependencies>
         <dependency>
@@ -52,6 +52,11 @@
             <groupId>org.wso2.healthcare.codegen.tool.framework</groupId>
             <artifactId>fhir-core</artifactId>
             <version>${version.healthcare.tool.framework}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.ballerina</groupId>
+            <artifactId>fhir-to-bal-lib</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
@@ -77,6 +82,17 @@
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${version.json.schema.validator}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.26.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -122,6 +138,16 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                     </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*Runner.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -316,6 +342,17 @@
                                         <argument>test</argument>
                                         <argument>target/test-classes/health.fhir.r5.europebase/</argument>
                                     </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>run-local-module-template-test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <configuration>
+                                    <mainClass>LocalModuleTemplateTestRunner</mainClass>
+                                    <classpathScope>test</classpathScope>
                                 </configuration>
                             </execution>
                         </executions>

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/config/IgRegistryConfig.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/config/IgRegistryConfig.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.config;
+
+import com.google.gson.JsonObject;
+import io.ballerina.health.cmd.core.utils.HealthCmdConstants;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration for FHIR IG package registry download ({@code fhir.igRegistry} in tool-config.json).
+ */
+public class IgRegistryConfig {
+
+    private final String registryUrl;
+    private final String cacheDir;
+    private final int httpTimeoutSeconds;
+    private final Map<String, IgPackageRef> defaultPackages;
+    private final Map<String, String> packageMappings;
+
+    public IgRegistryConfig(String registryUrl, String cacheDir, int httpTimeoutSeconds,
+                            Map<String, IgPackageRef> defaultPackages, Map<String, String> packageMappings) {
+        this.registryUrl = registryUrl;
+        this.cacheDir = cacheDir;
+        this.httpTimeoutSeconds = httpTimeoutSeconds;
+        this.defaultPackages = defaultPackages != null ? defaultPackages : Collections.emptyMap();
+        this.packageMappings = packageMappings != null ? packageMappings : Collections.emptyMap();
+    }
+
+    public static IgRegistryConfig fromFhirConfig(JsonObject fhirConfig) {
+        if (fhirConfig == null || !fhirConfig.has("igRegistry")) {
+            return defaults();
+        }
+        JsonObject igRegistry = fhirConfig.getAsJsonObject("igRegistry");
+        String registryUrl = getString(igRegistry, "registryUrl", HealthCmdConstants.CMD_DEFAULT_REGISTRY_URL);
+        String cacheDir = getString(igRegistry, "cacheDir", HealthCmdConstants.CMD_DEFAULT_IG_CACHE_DIR);
+        int timeout = igRegistry.has("httpTimeoutSeconds")
+                ? igRegistry.get("httpTimeoutSeconds").getAsInt()
+                : HealthCmdConstants.CMD_DEFAULT_IG_HTTP_TIMEOUT_SECONDS;
+
+        Map<String, IgPackageRef> defaultPackages = new HashMap<>();
+        if (igRegistry.has("defaultPackages")) {
+            JsonObject defaults = igRegistry.getAsJsonObject("defaultPackages");
+            for (String fhirVersion : defaults.keySet()) {
+                JsonObject pkg = defaults.getAsJsonObject(fhirVersion);
+                defaultPackages.put(fhirVersion, new IgPackageRef(
+                        pkg.get("name").getAsString(),
+                        pkg.get("version").getAsString()
+                ));
+            }
+        }
+        if (defaultPackages.isEmpty()) {
+            defaultPackages.put("r4", new IgPackageRef(
+                    HealthCmdConstants.CMD_DEFAULT_R4_IG_PACKAGE_NAME,
+                    HealthCmdConstants.CMD_DEFAULT_R4_IG_PACKAGE_VERSION));
+            defaultPackages.put("r5", new IgPackageRef(
+                    HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_NAME,
+                    HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_VERSION));
+        }
+
+        Map<String, String> mappings = new HashMap<>();
+        if (igRegistry.has("packageMappings")) {
+            JsonObject mappingObj = igRegistry.getAsJsonObject("packageMappings");
+            for (String key : mappingObj.keySet()) {
+                mappings.put(key, mappingObj.get(key).getAsString());
+            }
+        }
+
+        return new IgRegistryConfig(registryUrl, cacheDir, timeout, defaultPackages, mappings);
+    }
+
+    public static IgRegistryConfig defaults() {
+        Map<String, IgPackageRef> defaultPackages = Map.of(
+                "r4", new IgPackageRef(
+                        HealthCmdConstants.CMD_DEFAULT_R4_IG_PACKAGE_NAME,
+                        HealthCmdConstants.CMD_DEFAULT_R4_IG_PACKAGE_VERSION),
+                "r5", new IgPackageRef(
+                        HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_NAME,
+                        HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_VERSION)
+        );
+        return new IgRegistryConfig(
+                HealthCmdConstants.CMD_DEFAULT_REGISTRY_URL,
+                HealthCmdConstants.CMD_DEFAULT_IG_CACHE_DIR,
+                HealthCmdConstants.CMD_DEFAULT_IG_HTTP_TIMEOUT_SECONDS,
+                defaultPackages,
+                Collections.emptyMap()
+        );
+    }
+
+    private static String getString(JsonObject obj, String key, String defaultValue) {
+        if (obj.has(key) && !obj.get(key).getAsString().isEmpty()) {
+            return obj.get(key).getAsString();
+        }
+        return defaultValue;
+    }
+
+    public String getRegistryUrl() {
+        return registryUrl;
+    }
+
+    public String getCacheDir() {
+        return cacheDir;
+    }
+
+    public int getHttpTimeoutSeconds() {
+        return httpTimeoutSeconds;
+    }
+
+    public IgPackageRef getDefaultPackage(String fhirVersion) {
+        if (fhirVersion == null) {
+            return defaultPackages.get("r4");
+        }
+        return defaultPackages.getOrDefault(fhirVersion.toLowerCase(), defaultPackages.get("r4"));
+    }
+
+    public String resolveDependentPackage(String igName) {
+        return packageMappings.get(igName);
+    }
+
+    public record IgPackageRef(String name, String version) {
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloader.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloader.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.zip.GZIPInputStream;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+
+/**
+ * Downloads FHIR IG packages from the FHIR package registry and extracts JSON resources for codegen.
+ * Mirrors the fetch/extract flow in fhir-server-go {@code internal/ig}.
+ */
+public final class FhirIgPackageDownloader {
+
+    private static final String PACKAGE_PREFIX = "package/";
+    private static final String VERSION_LATEST_TAG = "latest";
+
+    private FhirIgPackageDownloader() {
+    }
+
+    public static ParsedIgSpec parseIgSpec(String igName, String igVersion) {
+        if (igName == null || igName.trim().isEmpty()) {
+            throw new IllegalArgumentException("IG package name cannot be empty");
+        }
+        String name = igName.trim();
+        String version = (igVersion == null || igVersion.trim().isEmpty())
+                ? VERSION_LATEST_TAG : igVersion.trim();
+        return new ParsedIgSpec(name, version);
+    }
+
+    public static String fetchPackageMetadata(String registryUrl, String packageName, int timeoutSeconds)
+            throws BallerinaHealthException {
+        String registryBase = registryUrl.replaceAll("/+$", "");
+        String metadataUrl = registryBase + "/" + packageName;
+        byte[] metadataBody = httpGet(metadataUrl, timeoutSeconds);
+        return new String(metadataBody, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Resolves the package version to download. When version is omitted or {@code latest}, fetches registry
+     * metadata and either prompts for a version (interactive) or uses {@code dist-tags.latest} (non-interactive).
+     */
+    public static String resolvePackageVersion(String registryUrl, String packageName, String requestedVersion,
+                                               DownloadOptions options) throws BallerinaHealthException {
+        if (!needsVersionResolution(requestedVersion)) {
+            return requestedVersion.trim();
+        }
+        String metadataJson = fetchPackageMetadata(registryUrl, packageName, options.httpTimeoutSeconds());
+        String latestTag = parseLatestVersionFromMetadata(metadataJson, packageName);
+        List<String> availableVersions = IgVersionSelector.parseAvailableVersions(metadataJson);
+        return IgVersionSelector.selectVersion(
+                packageName,
+                availableVersions,
+                latestTag,
+                options.nonInteractive(),
+                options.printStream());
+    }
+
+    /**
+     * Parses {@code dist-tags.latest} from FHIR package registry metadata JSON.
+     */
+    public static String parseLatestVersionFromMetadata(String metadataJson, String packageName)
+            throws BallerinaHealthException {
+        try {
+            JsonObject root = JsonParser.parseString(metadataJson).getAsJsonObject();
+            if (!root.has("dist-tags") || !root.get("dist-tags").isJsonObject()) {
+                throw new BallerinaHealthException("Package metadata for " + packageName
+                        + " does not contain dist-tags.");
+            }
+            JsonObject distTags = root.getAsJsonObject("dist-tags");
+            if (!distTags.has(VERSION_LATEST_TAG)
+                    || distTags.get(VERSION_LATEST_TAG).getAsString().trim().isEmpty()) {
+                throw new BallerinaHealthException("Package metadata for " + packageName
+                        + " does not contain dist-tags.latest.");
+            }
+            return distTags.get(VERSION_LATEST_TAG).getAsString().trim();
+        } catch (BallerinaHealthException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BallerinaHealthException("Failed to parse package metadata for " + packageName + ": "
+                    + e.getMessage(), e);
+        }
+    }
+
+    public static ParsedIgSpec resolveIgSpec(String igName, String igVersion, DownloadOptions options)
+            throws BallerinaHealthException {
+        ParsedIgSpec spec = parseIgSpec(igName, igVersion);
+        String resolvedVersion = resolvePackageVersion(options.registryUrl(), spec.name(), spec.version(), options);
+        return new ParsedIgSpec(spec.name(), resolvedVersion);
+    }
+
+    private static boolean needsVersionResolution(String requestedVersion) {
+        return requestedVersion == null || requestedVersion.trim().isEmpty()
+                || VERSION_LATEST_TAG.equalsIgnoreCase(requestedVersion.trim());
+    }
+
+    /**
+     * Downloads (or reads from cache) and extracts the IG package into {@code targetDirectory}.
+     */
+    public static Path downloadAndExtract(Path targetDirectory, String packageName, String packageVersion,
+                                         DownloadOptions options) throws BallerinaHealthException {
+        return downloadAndExtract(targetDirectory, resolveIgSpec(packageName, packageVersion, options), options);
+    }
+
+    /**
+     * Downloads (or reads from cache) and extracts the IG package into {@code targetDirectory}.
+     */
+    public static Path downloadAndExtract(Path targetDirectory, ParsedIgSpec spec, DownloadOptions options)
+            throws BallerinaHealthException {
+        if (!options.forceDownload()
+                && SpecificationPathUtils.containsStructureDefinitionResources(targetDirectory)) {
+            return targetDirectory;
+        }
+
+        try {
+            if (options.forceDownload() && Files.exists(targetDirectory)) {
+                deleteDirectoryContents(targetDirectory);
+            }
+            Files.createDirectories(targetDirectory);
+        } catch (IOException e) {
+            throw new BallerinaHealthException("Failed to prepare IG extract directory: " + targetDirectory, e);
+        }
+
+        byte[] tgzData = fetchPackageBytes(spec, options);
+        extractPackage(tgzData, targetDirectory);
+
+        if (!SpecificationPathUtils.containsStructureDefinitionResources(targetDirectory)) {
+            throw new BallerinaHealthException("Downloaded IG package did not contain any StructureDefinition "
+                    + "resources under " + targetDirectory);
+        }
+        return targetDirectory;
+    }
+
+    /**
+     * Extracts a FHIR package tarball into {@code targetDirectory} (for tests and local .tgz use).
+     */
+    public static void extractPackage(byte[] tgzData, Path targetDirectory) throws BallerinaHealthException {
+        try (InputStream gzipIn = new GZIPInputStream(new ByteArrayInputStream(tgzData));
+             TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn)) {
+            ArchiveEntry entry;
+            while ((entry = tarIn.getNextEntry()) != null) {
+                if (!entry.getName().startsWith(PACKAGE_PREFIX) || entry.isDirectory()) {
+                    continue;
+                }
+                String relative = entry.getName().substring(PACKAGE_PREFIX.length());
+                if (!relative.endsWith(".json")) {
+                    continue;
+                }
+                Path destination = targetDirectory.resolve(relative);
+                Files.createDirectories(destination.getParent());
+                writeEntry(tarIn, destination);
+            }
+        } catch (IOException e) {
+            throw new BallerinaHealthException("Failed to extract IG package: " + e.getMessage(), e);
+        }
+    }
+
+    private static byte[] fetchPackageBytes(ParsedIgSpec spec, DownloadOptions options)
+            throws BallerinaHealthException {
+        Path cachePath = resolveCachePath(options.cacheDir(), spec.name(), spec.version());
+        if (cachePath != null && Files.exists(cachePath) && !options.forceDownload()) {
+            try {
+                return Files.readAllBytes(cachePath);
+            } catch (IOException e) {
+                throw new BallerinaHealthException("Failed to read cached IG package: " + cachePath, e);
+            }
+        }
+
+        String registryUrl = options.registryUrl().replaceAll("/+$", "");
+        String url = registryUrl + "/" + spec.name() + "/" + spec.version();
+        byte[] data = httpGet(url, options.httpTimeoutSeconds());
+
+        if (cachePath != null) {
+            try {
+                Files.createDirectories(cachePath.getParent());
+                Files.write(cachePath, data);
+            } catch (IOException ignored) {
+                // best-effort cache write
+            }
+        }
+        return data;
+    }
+
+    static byte[] httpGet(String url, int timeoutSeconds) throws BallerinaHealthException {
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(timeoutSeconds))
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(timeoutSeconds))
+                    .GET()
+                    .build();
+            HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() != 200) {
+                throw new BallerinaHealthException("Failed to download IG package from " + url
+                        + " (HTTP " + response.statusCode() + ")");
+            }
+            return response.body();
+        } catch (BallerinaHealthException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BallerinaHealthException("Failed to download IG package from " + url + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static Path resolveCachePath(String cacheDir, String name, String version) {
+        if (cacheDir == null || cacheDir.isEmpty()) {
+            return null;
+        }
+        String safeName = name.replace('/', '_').replace('\\', '_');
+        return Path.of(cacheDir).resolve(safeName + "-" + version + ".tgz");
+    }
+
+    private static void writeEntry(TarArchiveInputStream tarIn, Path destination) throws IOException {
+        try (OutputStream out = Files.newOutputStream(destination)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = tarIn.read(buffer)) >= 0) {
+                out.write(buffer, 0, read);
+            }
+        }
+    }
+
+    private static void deleteDirectoryContents(Path directory) throws BallerinaHealthException {
+        try (var paths = Files.walk(directory)) {
+            paths.sorted((a, b) -> b.compareTo(a))
+                    .filter(path -> !path.equals(directory))
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof IOException io) {
+                throw new BallerinaHealthException("Failed to clear directory " + directory, io);
+            }
+            throw e;
+        } catch (IOException e) {
+            throw new BallerinaHealthException("Failed to clear directory " + directory, e);
+        }
+    }
+
+    public static String sanitizeIgDirectoryName(String igName) {
+        return igName.replace('.', '_').replace('/', '_').toLowerCase(Locale.ROOT);
+    }
+
+    public record ParsedIgSpec(String name, String version) {
+        public String source() {
+            return name + "@" + version;
+        }
+    }
+
+    public record DownloadOptions(
+            String registryUrl,
+            String cacheDir,
+            int httpTimeoutSeconds,
+            boolean forceDownload,
+            boolean nonInteractive,
+            PrintStream printStream
+    ) {
+        public DownloadOptions(String registryUrl, String cacheDir, int httpTimeoutSeconds, boolean forceDownload) {
+            this(registryUrl, cacheDir, httpTimeoutSeconds, forceDownload, false, System.out);
+        }
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
@@ -36,6 +36,21 @@ public class HealthCmdConstants {
     public static final String CMD_CDS_HELP_TEXT_FILENAME = "ballerina-health-cds.help";
     public static final String CMD_DEFAULT_IG_NAME = "FHIR";
     public static final String CMD_DEFAULT_ORG_NAME = "healthcare";
+    public static final String CMD_DEFAULT_R4_DEPENDENT_PACKAGE = "ballerinax/health.fhir.r4.international401";
+    public static final String CMD_DEFAULT_R5_DEPENDENT_PACKAGE = "ballerinax/health.fhir.r5.international500";
+    public static final String CMD_DEFAULT_INTERNATIONAL_IG_DIR = "international";
+    public static final String CMD_DEFAULT_REGISTRY_URL = "https://packages.fhir.org";
+    public static final String CMD_DEFAULT_IG_CACHE_DIR = ".fhir-ig-cache";
+    public static final int CMD_DEFAULT_IG_HTTP_TIMEOUT_SECONDS = 60;
+    public static final String CMD_DEFAULT_R4_IG_PACKAGE_NAME = "hl7.fhir.r4.core";
+    public static final String CMD_DEFAULT_R4_IG_PACKAGE_VERSION = "4.0.1";
+    public static final String CMD_DEFAULT_R5_IG_PACKAGE_NAME = "hl7.fhir.r5.core";
+    public static final String CMD_DEFAULT_R5_IG_PACKAGE_VERSION = "5.0.0";
+    public static final String CMD_OPTION_IG_NAME = "--ig-name";
+    public static final String CMD_OPTION_IG_VERSION = "--ig-version";
+    public static final String CMD_OPTION_REGISTRY_URL = "--registry-url";
+    public static final String CMD_OPTION_IG_CACHE_DIR = "--ig-cache-dir";
+    public static final String CMD_OPTION_FORCE_IG_DOWNLOAD = "--force-ig-download";
     public static final String CMD_FHIR_MODE_TEMPLATE = "fhir:template";
     public static final String CMD_FHIR_MODE_CLIENT = "fhir:client";
     public static final String CMD_FHIR_MODE_PACKAGE = "fhir:package";
@@ -103,8 +118,12 @@ public class HealthCmdConstants {
         public static final String PKG_NAME_REQUIRED = "[ERROR] Package name [--package-name] is required for package "
                 + "generation.";
         public static final String GEN_ERROR = "[ERROR] Error occurred while generating the Ballerina artifacts.";
-        public static final String DEPENDENT_REQUIRED = "[ERROR] Dependent package [--dependent-package] is required "
-                + "for template generation.";
+        public static final String DEPENDENT_REQUIRED = "[ERROR] --dependent-package, --ig-name, or a resolvable spec "
+                + "path (local or registry download) is required for template generation.";
+        public static final String IG_DOWNLOAD_SUCCESS = "[INFO] Downloaded IG package ";
+        public static final String SPEC_PATH_REQUIRED = "[ERROR] FHIR specification path or --ig-name is required.";
+        public static final String USING_INTERNATIONAL_BASE = "[INFO] No custom IG specified. Using international "
+                + "base FHIR structure definitions with ";
         public static final String DEPENDENT_INCORRECT = "[ERROR] Format of the dependent package is incorrect.";
         public static final String INCLUDED_EXCLUDED_TOGETHER = "[ERROR] Both --included-profile and "
                 + "--excluded-profile cannot be used together.";

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
@@ -81,7 +81,7 @@ public class HealthCmdUtils {
     }
 
     public static Path getSpecificationPath(String specPathParam, String executionPath) throws BallerinaHealthException {
-        if (specPathParam == null && specPathParam.isEmpty()) {
+        if (specPathParam == null || specPathParam.isEmpty()) {
             throw new BallerinaHealthException("Cannot find valid spec path pointed. Please check the path "
                     + specPathParam + " is valid.");
         }

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgModuleNameUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgModuleNameUtils.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.wso2.healthcare.fhir.ballerina.packagegen.tool.utils.GeneratorUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Utilities for deriving Ballerina module names from FHIR implementation guide identifiers.
+ */
+public final class IgModuleNameUtils {
+
+    private static final String MODULE_NAME_PATTERN = "^[a-zA-Z][a-zA-Z0-9_]*$";
+
+    private IgModuleNameUtils() {
+    }
+
+    public static boolean isValidBallerinaModuleName(String moduleName) {
+        return moduleName != null && !moduleName.isEmpty() && moduleName.matches(MODULE_NAME_PATTERN);
+    }
+
+    public static String inferIgModuleName(String specificationPath) throws IOException {
+        String igIdentifier = findImplementationGuideIdentifier(specificationPath);
+        if (igIdentifier == null || igIdentifier.isEmpty()) {
+            igIdentifier = inferIgNameFromDirectory(specificationPath);
+        }
+        return toBallerinaModuleName(igIdentifier);
+    }
+
+    public static String toBallerinaModuleName(String igIdentifier) {
+        if (igIdentifier == null || igIdentifier.trim().isEmpty()) {
+            throw new IllegalArgumentException("IG identifier cannot be empty");
+        }
+        String normalized = igIdentifier.trim().replace('.', '_');
+        normalized = GeneratorUtils.getInstance().resolveSpecialCharacters(normalized);
+        normalized = camelCaseToSnakeCase(normalized);
+        normalized = normalized.replaceAll("[^a-zA-Z0-9_]", "_").replaceAll("_+", "_");
+        if (normalized.endsWith("_")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("Unable to derive a Ballerina module name from IG identifier: "
+                    + igIdentifier);
+        }
+        if (!Character.isLetter(normalized.charAt(0))) {
+            normalized = "ig_" + normalized;
+        }
+        return normalized;
+    }
+
+    private static String camelCaseToSnakeCase(String value) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (Character.isUpperCase(current) && i > 0 && builder.charAt(builder.length() - 1) != '_') {
+                builder.append('_');
+            }
+            builder.append(Character.toLowerCase(current));
+        }
+        return builder.toString();
+    }
+
+    private static String findImplementationGuideIdentifier(String specificationPath) throws IOException {
+        try (Stream<Path> paths = Files.walk(Paths.get(specificationPath))) {
+            List<Path> implementationGuideFiles = paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".json"))
+                    .filter(path -> path.getFileName().toString().startsWith("ImplementationGuide")
+                            || path.getFileName().toString().contains("ImplementationGuide"))
+                    .toList();
+
+            for (Path path : implementationGuideFiles) {
+                try {
+                    JsonObject json = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+                    if (!json.has("resourceType")
+                            || !"ImplementationGuide".equals(json.get("resourceType").getAsString())) {
+                        continue;
+                    }
+                    if (json.has("name") && !json.get("name").getAsString().isEmpty()) {
+                        return json.get("name").getAsString();
+                    }
+                    if (json.has("packageId") && !json.get("packageId").getAsString().isEmpty()) {
+                        return json.get("packageId").getAsString();
+                    }
+                    if (json.has("id") && !json.get("id").getAsString().isEmpty()) {
+                        return json.get("id").getAsString();
+                    }
+                } catch (Exception ignored) {
+                    // try next candidate file
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String inferIgNameFromDirectory(String specificationPath) {
+        Path specPath = Paths.get(specificationPath);
+        String directoryName = specPath.getFileName().toString();
+        int separatorIndex = directoryName.lastIndexOf('.');
+        if (separatorIndex >= 0 && separatorIndex < directoryName.length() - 1) {
+            return directoryName.substring(separatorIndex + 1);
+        }
+        return directoryName;
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgRegistryConfigLoader.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgRegistryConfigLoader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import io.ballerina.health.cmd.core.config.HealthCmdConfig;
+import io.ballerina.health.cmd.core.config.IgRegistryConfig;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Loads {@link IgRegistryConfig} from the packaged tool-config.json.
+ */
+public final class IgRegistryConfigLoader {
+
+    private IgRegistryConfigLoader() {
+    }
+
+    public static IgRegistryConfig load() {
+        try (InputStream stream = IgRegistryConfigLoader.class.getClassLoader()
+                .getResourceAsStream(HealthCmdConstants.CMD_CONFIG_FILENAME)) {
+            if (stream == null) {
+                return IgRegistryConfig.defaults();
+            }
+            JsonObject config = HealthCmdConfig.getParsedConfigFromStream(stream);
+            if (config != null && config.has("fhir")) {
+                return IgRegistryConfig.fromFhirConfig(config.getAsJsonObject("fhir"));
+            }
+        } catch (BallerinaHealthException | IOException ignored) {
+            // use defaults
+        }
+        return IgRegistryConfig.defaults();
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgVersionSelector.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgVersionSelector.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.Console;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Parses FHIR package registry metadata and interactively selects a package version when needed.
+ */
+public final class IgVersionSelector {
+
+    private IgVersionSelector() {
+    }
+
+    /**
+     * Returns published version ids from registry metadata, sorted newest-first (approximate semver ordering).
+     */
+    public static List<String> parseAvailableVersions(String metadataJson) throws BallerinaHealthException {
+        try {
+            JsonObject root = JsonParser.parseString(metadataJson).getAsJsonObject();
+            if (!root.has("versions") || !root.get("versions").isJsonObject()) {
+                throw new BallerinaHealthException("Package metadata does not contain a versions map.");
+            }
+            Set<Map.Entry<String, com.google.gson.JsonElement>> entries =
+                    root.getAsJsonObject("versions").entrySet();
+            List<String> versions = new ArrayList<>();
+            for (Map.Entry<String, com.google.gson.JsonElement> entry : entries) {
+                versions.add(entry.getKey());
+            }
+            versions.sort(IgVersionSelector::compareVersionsDesc);
+            return versions;
+        } catch (BallerinaHealthException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BallerinaHealthException("Failed to parse available versions from package metadata: "
+                    + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Prompts the user to choose a version. When no console is available or {@code nonInteractive} is true,
+     * returns {@code latestTagVersion} without prompting.
+     */
+    public static String selectVersion(String packageName, List<String> availableVersions, String latestTagVersion,
+                                       boolean nonInteractive, PrintStream out) throws BallerinaHealthException {
+        if (availableVersions == null || availableVersions.isEmpty()) {
+            if (latestTagVersion != null && !latestTagVersion.isEmpty()) {
+                return latestTagVersion;
+            }
+            throw new BallerinaHealthException("No published versions found for package " + packageName + ".");
+        }
+
+        if (nonInteractive || !isInteractiveConsoleAvailable()) {
+            if (latestTagVersion != null && availableVersions.contains(latestTagVersion)) {
+                return latestTagVersion;
+            }
+            return availableVersions.get(0);
+        }
+
+        PrintStream output = out != null ? out : System.out;
+        int defaultIndex = resolveDefaultIndex(availableVersions, latestTagVersion);
+        output.println("[INFO] Available versions for " + packageName + ":");
+        for (int i = 0; i < availableVersions.size(); i++) {
+            String suffix = (i == defaultIndex) ? " (default)" : "";
+            output.printf("  [%d] %s%s%n", i + 1, availableVersions.get(i), suffix);
+        }
+
+        Console console = System.console();
+        while (true) {
+            String prompt = "Select version [1-" + availableVersions.size() + "] (default "
+                    + (defaultIndex + 1) + "): ";
+            String input = console.readLine(prompt);
+            if (input == null || input.trim().isEmpty()) {
+                return availableVersions.get(defaultIndex);
+            }
+            String trimmed = input.trim();
+            if (trimmed.matches("\\d+")) {
+                int choice = Integer.parseInt(trimmed);
+                if (choice >= 1 && choice <= availableVersions.size()) {
+                    return availableVersions.get(choice - 1);
+                }
+                output.println("[ERROR] Invalid selection. Enter a number between 1 and "
+                        + availableVersions.size() + ".");
+                continue;
+            }
+            if (availableVersions.contains(trimmed)) {
+                return trimmed;
+            }
+            output.println("[ERROR] Unknown version '" + trimmed + "'. Choose from the list above.");
+        }
+    }
+
+    static boolean isInteractiveConsoleAvailable() {
+        return System.console() != null;
+    }
+
+    private static int resolveDefaultIndex(List<String> availableVersions, String latestTagVersion) {
+        if (latestTagVersion != null) {
+            int index = availableVersions.indexOf(latestTagVersion);
+            if (index >= 0) {
+                return index;
+            }
+        }
+        return 0;
+    }
+
+    static int compareVersionsDesc(String left, String right) {
+        return compareVersions(right, left);
+    }
+
+    static int compareVersions(String left, String right) {
+        VersionParts leftParts = splitVersionParts(left);
+        VersionParts rightParts = splitVersionParts(right);
+        int baseCompare = compareBaseVersion(leftParts.base(), rightParts.base());
+        if (baseCompare != 0) {
+            return baseCompare;
+        }
+        return comparePrerelease(leftParts.prerelease(), rightParts.prerelease());
+    }
+
+    private static VersionParts splitVersionParts(String version) {
+        int dash = version.indexOf('-');
+        if (dash < 0) {
+            return new VersionParts(version, "");
+        }
+        return new VersionParts(version.substring(0, dash), version.substring(dash + 1));
+    }
+
+    private static int compareBaseVersion(String left, String right) {
+        String[] leftParts = left.split("\\.");
+        String[] rightParts = right.split("\\.");
+        int max = Math.max(leftParts.length, rightParts.length);
+        for (int i = 0; i < max; i++) {
+            String l = i < leftParts.length ? leftParts[i] : "";
+            String r = i < rightParts.length ? rightParts[i] : "";
+            int partCompare = compareVersionPart(l, r);
+            if (partCompare != 0) {
+                return partCompare;
+            }
+        }
+        return 0;
+    }
+
+    private static int comparePrerelease(String left, String right) {
+        if (left.isEmpty() && right.isEmpty()) {
+            return 0;
+        }
+        if (left.isEmpty()) {
+            return 1;
+        }
+        if (right.isEmpty()) {
+            return -1;
+        }
+        return left.compareToIgnoreCase(right);
+    }
+
+    private record VersionParts(String base, String prerelease) {
+    }
+
+    private static int compareVersionPart(String left, String right) {
+        boolean leftNumeric = left.matches("\\d+");
+        boolean rightNumeric = right.matches("\\d+");
+        if (leftNumeric && rightNumeric) {
+            return Integer.compare(Integer.parseInt(left), Integer.parseInt(right));
+        }
+        return left.compareToIgnoreCase(right);
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import io.ballerina.health.cmd.core.config.IgRegistryConfig;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Resolves FHIR specification directories, optionally downloading IG packages from the FHIR registry first.
+ */
+public final class SpecificationPathResolver {
+
+    private SpecificationPathResolver() {
+    }
+
+    public static ResolvedSpecification resolve(ResolveRequest request) throws BallerinaHealthException {
+        IgRegistryConfig registryConfig = request.registryConfig() != null
+                ? request.registryConfig() : IgRegistryConfig.defaults();
+
+        String cacheDir = resolveCacheDir(request.cacheDir(), request.executionPath(), registryConfig.getCacheDir());
+        PrintStream out = request.printStream() != null ? request.printStream() : System.out;
+        FhirIgPackageDownloader.DownloadOptions downloadOptions = new FhirIgPackageDownloader.DownloadOptions(
+                request.registryUrl() != null ? request.registryUrl() : registryConfig.getRegistryUrl(),
+                cacheDir,
+                registryConfig.getHttpTimeoutSeconds(),
+                request.forceDownload(),
+                request.nonInteractive(),
+                out
+        );
+
+        if (request.igName() != null && !request.igName().isEmpty()) {
+            Path targetDir = Paths.get(request.executionPath(), "spec",
+                    FhirIgPackageDownloader.sanitizeIgDirectoryName(request.igName()));
+            downloadIg(request, registryConfig, request.igName(), request.igVersion(), targetDir, downloadOptions);
+            String mapped = registryConfig.resolveDependentPackage(request.igName());
+            return new ResolvedSpecification(targetDir, request.igName(), mapped);
+        }
+
+        if (request.specPathArg() != null && !request.specPathArg().trim().isEmpty()) {
+            if (CMD_MODE_TEMPLATE.equals(request.mode())) {
+                Path path = SpecificationPathUtils.resolveTemplateSpecificationPath(
+                        request.specPathArg(), request.executionPath());
+                return new ResolvedSpecification(path, null, null);
+            }
+            Path path = HealthCmdUtils.validateAndSetSpecificationPath(
+                    request.specPathArg(), request.executionPath());
+            return new ResolvedSpecification(path, null, null);
+        }
+
+        IgRegistryConfig.IgPackageRef defaultPkg = registryConfig.getDefaultPackage(
+                request.fhirVersion() != null ? request.fhirVersion() : "r4");
+        Path targetDir = Paths.get(request.executionPath(), "spec",
+                HealthCmdConstants.CMD_DEFAULT_INTERNATIONAL_IG_DIR);
+        downloadIg(request, registryConfig, defaultPkg.name(), defaultPkg.version(), targetDir, downloadOptions);
+        String mappedDependent = defaultDependentForIgPackage(defaultPkg.name(), registryConfig, request.igName());
+        if (CMD_MODE_TEMPLATE.equals(request.mode())) {
+            Path path = SpecificationPathUtils.resolveTemplateSpecificationPath(null, request.executionPath());
+            return new ResolvedSpecification(path, defaultPkg.name(), mappedDependent);
+        }
+        return new ResolvedSpecification(targetDir, defaultPkg.name(), mappedDependent);
+    }
+
+    private static String defaultDependentForIgPackage(String packageName, IgRegistryConfig registryConfig,
+                                                       String igName) {
+        String mapped = igName != null ? registryConfig.resolveDependentPackage(igName) : null;
+        if (mapped != null) {
+            return mapped;
+        }
+        if (HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_NAME.equals(packageName)) {
+            return HealthCmdConstants.CMD_DEFAULT_R5_DEPENDENT_PACKAGE;
+        }
+        return HealthCmdConstants.CMD_DEFAULT_R4_DEPENDENT_PACKAGE;
+    }
+
+    public static boolean canResolveWithoutLocalSpec(ResolveRequest request) {
+        if (request.igName() != null && !request.igName().isEmpty()) {
+            return true;
+        }
+        if (request.specPathArg() != null && !request.specPathArg().trim().isEmpty()) {
+            return true;
+        }
+        return CMD_MODE_TEMPLATE.equals(request.mode()) || CMD_MODE_PACKAGE.equals(request.mode());
+    }
+
+    private static void downloadIg(ResolveRequest request, IgRegistryConfig registryConfig,
+                                   String packageName, String packageVersion, Path targetDir,
+                                   FhirIgPackageDownloader.DownloadOptions downloadOptions)
+            throws BallerinaHealthException {
+        FhirIgPackageDownloader.ParsedIgSpec spec =
+                FhirIgPackageDownloader.resolveIgSpec(packageName, packageVersion, downloadOptions);
+        PrintStream out = downloadOptions.printStream() != null ? downloadOptions.printStream() : System.out;
+        out.println(HealthCmdConstants.PrintStrings.IG_DOWNLOAD_SUCCESS + spec.source()
+                + " into " + targetDir + " ...");
+        FhirIgPackageDownloader.downloadAndExtract(targetDir, spec, downloadOptions);
+    }
+
+    private static String resolveCacheDir(String override, String executionPath, String configured) {
+        if (override != null && !override.isEmpty()) {
+            return Paths.get(override).isAbsolute()
+                    ? override : Paths.get(executionPath, override).toString();
+        }
+        return Paths.get(executionPath, configured).toString();
+    }
+
+    private static final String CMD_MODE_TEMPLATE = HealthCmdConstants.CMD_MODE_TEMPLATE;
+    private static final String CMD_MODE_PACKAGE = HealthCmdConstants.CMD_MODE_PACKAGE;
+
+    public record ResolveRequest(
+            String mode,
+            String executionPath,
+            String specPathArg,
+            String igName,
+            String igVersion,
+            String registryUrl,
+            String cacheDir,
+            boolean forceDownload,
+            boolean nonInteractive,
+            String fhirVersion,
+            IgRegistryConfig registryConfig,
+            PrintStream printStream
+    ) {
+    }
+
+    public record ResolvedSpecification(Path specificationPath, String igPackageName, String mappedDependentPackage) {
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathUtils.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Resolves FHIR specification directories for template generation, including the
+ * international base R4 structure-definition layout documented under spec-path/international.
+ */
+public final class SpecificationPathUtils {
+
+    private static final String INTERNATIONAL_IG_DIR = "international";
+    private static final String STRUCTURE_DEFINITION_PREFIX = "StructureDefinition";
+    private static final String HL7_BASE_STRUCTURE_DEFINITION_URL_PREFIX =
+            "http://hl7.org/fhir/StructureDefinition/";
+
+    private SpecificationPathUtils() {
+    }
+
+    /**
+     * Resolves the directory that contains FHIR structure definitions for template generation.
+     * When the given path is a spec root (with IG subfolders), the international subdirectory is used.
+     * When no path is given, {@code <executionPath>/spec/international} is used.
+     */
+    public static Path resolveTemplateSpecificationPath(String specPathParam, String executionPath)
+            throws BallerinaHealthException {
+        if (specPathParam != null && !specPathParam.trim().isEmpty()) {
+            Path specificationPath = HealthCmdUtils.getSpecificationPath(specPathParam, executionPath);
+            if (!Files.isDirectory(specificationPath)) {
+                throw new BallerinaHealthException("Cannot find valid spec path pointed. Please check the path "
+                        + specPathParam + " is valid.");
+            }
+            if (containsStructureDefinitionResources(specificationPath)) {
+                return specificationPath;
+            }
+            Path internationalPath = specificationPath.resolve(INTERNATIONAL_IG_DIR);
+            if (Files.isDirectory(internationalPath) && containsStructureDefinitionResources(internationalPath)) {
+                return internationalPath;
+            }
+            throw new BallerinaHealthException("No FHIR StructureDefinition resources found under "
+                    + specificationPath + ". Point to an IG folder or to a spec root that contains an '"
+                    + INTERNATIONAL_IG_DIR + "' directory with HL7 international base R4 definitions.");
+        }
+
+        Path defaultInternationalPath = Paths.get(executionPath, "spec", INTERNATIONAL_IG_DIR);
+        if (Files.isDirectory(defaultInternationalPath) && containsStructureDefinitionResources(defaultInternationalPath)) {
+            return defaultInternationalPath;
+        }
+        throw new BallerinaHealthException("No IG specification path provided. Either pass the path to FHIR "
+                + "definitions as the last argument, or place HL7 international base R4 StructureDefinition "
+                + "files under spec/international relative to the working directory.");
+    }
+
+    /**
+     * Returns true when the specification path only contains HL7 international base structure definitions
+     * (no regional or custom implementation guide profiles).
+     */
+    public static boolean isInternationalBaseSpecification(String specificationPath) throws IOException {
+        Path specPath = Path.of(specificationPath);
+        if (specPath.getFileName() != null
+                && INTERNATIONAL_IG_DIR.equalsIgnoreCase(specPath.getFileName().toString())) {
+            return true;
+        }
+        if (hasCustomImplementationGuide(specPath)) {
+            return false;
+        }
+        return containsOnlyHl7BaseStructureDefinitions(specPath);
+    }
+
+    public static boolean containsStructureDefinitionResources(Path directory) throws BallerinaHealthException {
+        try {
+            if (!Files.isDirectory(directory)) {
+                return false;
+            }
+            try (Stream<Path> paths = Files.walk(directory, 2)) {
+                return paths
+                        .filter(Files::isRegularFile)
+                        .filter(path -> path.getFileName().toString().startsWith(STRUCTURE_DEFINITION_PREFIX))
+                        .anyMatch(SpecificationPathUtils::isStructureDefinitionFile);
+            }
+        } catch (IOException e) {
+            throw new BallerinaHealthException("Unable to read specification path: " + directory, e);
+        }
+    }
+
+    private static boolean hasCustomImplementationGuide(Path specificationPath) throws IOException {
+        try (Stream<Path> paths = Files.walk(specificationPath, 2)) {
+            List<Path> implementationGuideFiles = paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().startsWith("ImplementationGuide")
+                            || path.getFileName().toString().contains("ImplementationGuide"))
+                    .toList();
+
+            for (Path path : implementationGuideFiles) {
+                try {
+                    JsonObject json = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+                    if (!json.has("resourceType")
+                            || !"ImplementationGuide".equals(json.get("resourceType").getAsString())) {
+                        continue;
+                    }
+                    if (json.has("packageId") && !json.get("packageId").getAsString().isEmpty()) {
+                        return true;
+                    }
+                    if (json.has("name") && !json.get("name").getAsString().isEmpty()
+                            && !"FHIR".equalsIgnoreCase(json.get("name").getAsString())) {
+                        return true;
+                    }
+                } catch (Exception ignored) {
+                    // try next candidate file
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsOnlyHl7BaseStructureDefinitions(Path specificationPath) throws IOException {
+        boolean foundStructureDefinition = false;
+        try (Stream<Path> paths = Files.walk(specificationPath, 2)) {
+            List<Path> structureDefinitionFiles = paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().startsWith(STRUCTURE_DEFINITION_PREFIX))
+                    .toList();
+
+            for (Path path : structureDefinitionFiles) {
+                if (!isStructureDefinitionFile(path)) {
+                    continue;
+                }
+                foundStructureDefinition = true;
+                try {
+                    JsonObject json = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+                    if (!json.has("url")) {
+                        return false;
+                    }
+                    String url = json.get("url").getAsString();
+                    if (!url.startsWith(HL7_BASE_STRUCTURE_DEFINITION_URL_PREFIX)) {
+                        return false;
+                    }
+                    String resourceName = url.substring(HL7_BASE_STRUCTURE_DEFINITION_URL_PREFIX.length());
+                    if (resourceName.contains("/")) {
+                        return false;
+                    }
+                } catch (Exception e) {
+                    return false;
+                }
+            }
+        }
+        return foundStructureDefinition;
+    }
+
+    private static boolean isStructureDefinitionFile(Path path) {
+        try {
+            JsonObject json = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+            return json.has("resourceType")
+                    && "StructureDefinition".equals(json.get("resourceType").getAsString());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -41,6 +41,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.LogManager;
 
+import io.ballerina.health.cmd.core.config.IgRegistryConfig;
+import io.ballerina.health.cmd.core.utils.IgModuleNameUtils;
+import io.ballerina.health.cmd.core.utils.IgRegistryConfigLoader;
+import io.ballerina.health.cmd.core.utils.SpecificationPathResolver;
+
 import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.*;
 
 @CommandLine.Command(name = "fhir", description = "Generates Ballerina service/client for FHIR contract " +
@@ -87,11 +92,14 @@ public class FhirSubCmd implements BLauncherCmd {
     @CommandLine.Option(names = "--dependent-package", description = "Dependent package name for the templates to be generated")
     private String dependentPackage;
 
+    @CommandLine.Option(names = "--ig-module-name", description = "Optional module name for embedded IG resources (default: inferred from the IG). Ignored when --dependent-package is set")
+    private String igModuleName;
+
     @CommandLine.Option(names = "--dependent-ig", description = "Dependent IG base URL and respective fully qualified Ballerina package name")
     private String[] dependentIgs;
 
-    @CommandLine.Option(names = "--aggregate", description = "Enable aggregated API mode to generate a single service with multiple FHIR resources")
-    private boolean aggregate;
+    @CommandLine.Option(names = "--aggregate", description = "Aggregated API mode (default: true). Pass --aggregate false for separate services per resource", defaultValue = "true", fallbackValue = "true", arity = "0..1")
+    private boolean aggregate = true;
 
     @CommandLine.Option(names = "--resources", description = "Comma-separated list of FHIR resources to include. If not specified, all available resources will be included")
     private String resources;
@@ -99,6 +107,23 @@ public class FhirSubCmd implements BLauncherCmd {
     @CommandLine.Option(names = "--minimal", description = "Enable minimal generation mode to skip .choreo folder, OAS files, .gitignore, and Ballerina.toml. Only generates core service files")
     private boolean minimal;
 
+    @CommandLine.Option(names = "--ig-name", description = "FHIR registry package id (e.g. hl7.fhir.us.core). Downloads from packages.fhir.org when no local spec path is given")
+    private String igName;
+
+    @CommandLine.Option(names = "--ig-version", description = "FHIR registry package version (e.g. 6.1.0). If omitted, interactively selects from published versions (or dist-tags.latest with --non-interactive)")
+    private String igVersion;
+
+    @CommandLine.Option(names = "--non-interactive", description = "Skip interactive IG version selection; use dist-tags.latest when --ig-version is omitted")
+    private boolean nonInteractive;
+
+    @CommandLine.Option(names = "--registry-url", description = "FHIR package registry base URL (default: https://packages.fhir.org)")
+    private String registryUrl;
+
+    @CommandLine.Option(names = "--ig-cache-dir", description = "Directory to cache downloaded IG .tgz files (default: .fhir-ig-cache under the working directory)")
+    private String igCacheDir;
+
+    @CommandLine.Option(names = "--force-ig-download", description = "Re-download and re-extract the IG package even if definitions already exist locally")
+    private boolean forceIgDownload;
 
     @CommandLine.Parameters(description = "Custom arguments")
     private List<String> argList;
@@ -140,9 +165,15 @@ public class FhirSubCmd implements BLauncherCmd {
             printStream.println(HealthCmdConstants.PrintStrings.HELP_ERROR);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
-        if (!CMD_CONNECTOR.equals(mode) && (argList == null || argList.isEmpty())) {
-            //at minimum arg count is 1 (spec path)
+        if (!CMD_CONNECTOR.equals(mode) && !CMD_MODE_TEMPLATE.equals(mode) && !CMD_MODE_PACKAGE.equals(mode)
+                && (argList == null || argList.isEmpty())) {
             printStream.println(HealthCmdConstants.PrintStrings.INVALID_NUM_OF_ARGS);
+            printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
+            HealthCmdUtils.exitError(exitWhenFinish);
+        }
+        if (CMD_MODE_PACKAGE.equals(mode) && (argList == null || argList.isEmpty())
+                && (igName == null || igName.isEmpty()) && !canResolveSpecificationFromRegistry()) {
+            printStream.println(HealthCmdConstants.PrintStrings.SPEC_PATH_REQUIRED);
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
@@ -158,8 +189,10 @@ public class FhirSubCmd implements BLauncherCmd {
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
-        if (CMD_MODE_TEMPLATE.equals(mode) && (dependentPackage == null || dependentPackage.isEmpty())) {
-            // dependent package is a required param in template mode
+        if (CMD_MODE_TEMPLATE.equals(mode) &&
+                (dependentPackage == null || dependentPackage.isEmpty()) &&
+                (igName == null || igName.isEmpty()) &&
+                !canResolveSpecificationFromRegistry()) {
             printStream.println(HealthCmdConstants.PrintStrings.DEPENDENT_REQUIRED);
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
@@ -172,9 +205,9 @@ public class FhirSubCmd implements BLauncherCmd {
                 HealthCmdUtils.exitError(exitWhenFinish);
             }
         }
-        if (CMD_MODE_TEMPLATE.equals(mode) && (dependentPackage == null || dependentPackage.isEmpty())) {
-            // dependent package is a required param in template mode
-            printStream.println(HealthCmdConstants.PrintStrings.DEPENDENT_REQUIRED);
+        if (!CMD_CONNECTOR.equals(mode) && igModuleName != null && !igModuleName.isEmpty()
+                && !IgModuleNameUtils.isValidBallerinaModuleName(igModuleName)) {
+            printStream.println("Invalid IG module name.");
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
@@ -226,20 +259,9 @@ public class FhirSubCmd implements BLauncherCmd {
     }
 
     public boolean engageSubCommand(String mode, List<String> argList) {
-
-        Map<String, Object> argsMap = new HashMap<>();
-        argsMap.put("--package-name", packageName);
-        argsMap.put("--org-name", orgName);
-        argsMap.put("--package-version", packageVersion);
-        argsMap.put("--included-profile", includedProfiles);
-        argsMap.put("--excluded-profile", excludedProfiles);
-        argsMap.put("--dependent-package", dependentPackage);
-        argsMap.put("--dependent-ig", dependentIgs);
-        argsMap.put("--aggregate", aggregate);
-        argsMap.put("--resources", resources);
-        argsMap.put("--minimal", minimal);
         getTargetOutputPath();
 
+        boolean explicitDependentPackage = dependentPackage != null && !dependentPackage.isEmpty();
         if (CMD_MODE_CONNECTOR.equals(mode)) {
             try {
                 specificationPath = HealthCmdUtils.getSpecificationPath(configPath, executionPath.toString());
@@ -248,14 +270,51 @@ public class FhirSubCmd implements BLauncherCmd {
                 throw new BLauncherException();
             }
         } else {
-            //spec path is the last argument
             try {
-                specificationPath = HealthCmdUtils.validateAndSetSpecificationPath(argList.get(argList.size() - 1), executionPath.toString());
+                String specPathArg = (argList == null || argList.isEmpty()) ? null : argList.get(argList.size() - 1);
+                IgRegistryConfig registryConfig = IgRegistryConfigLoader.load();
+                SpecificationPathResolver.ResolvedSpecification resolved =
+                        SpecificationPathResolver.resolve(new SpecificationPathResolver.ResolveRequest(
+                                mode,
+                                executionPath.toString(),
+                                specPathArg,
+                                igName,
+                                igVersion,
+                                registryUrl,
+                                igCacheDir,
+                                forceIgDownload,
+                                nonInteractive,
+                                null,
+                                registryConfig,
+                                printStream
+                        ));
+                specificationPath = resolved.specificationPath();
+                if (CMD_MODE_TEMPLATE.equals(mode) && !explicitDependentPackage
+                        && resolved.mappedDependentPackage() != null) {
+                    printStream.println("[INFO] IG " + resolved.igPackageName()
+                            + " maps to published package " + resolved.mappedDependentPackage()
+                            + ". Embedding IG resources in the template (use --dependent-package to import that package instead).");
+                }
             } catch (BallerinaHealthException e) {
+                printStream.println(e.getMessage());
                 printStream.println(HealthCmdConstants.PrintStrings.INVALID_SPEC_PATH);
                 throw new BLauncherException();
             }
         }
+
+        Map<String, Object> argsMap = new HashMap<>();
+        argsMap.put("--package-name", packageName);
+        argsMap.put("--org-name", orgName);
+        argsMap.put("--package-version", packageVersion);
+        argsMap.put("--included-profile", includedProfiles);
+        argsMap.put("--excluded-profile", excludedProfiles);
+        argsMap.put("--explicit-dependent-package", explicitDependentPackage);
+        argsMap.put("--dependent-package", explicitDependentPackage ? dependentPackage : null);
+        argsMap.put("--ig-module-name", igModuleName);
+        argsMap.put("--dependent-ig", dependentIgs);
+        argsMap.put("--aggregate", aggregate);
+        argsMap.put("--resources", resources);
+        argsMap.put("--minimal", minimal);
 
         Handler toolHandler = null;
         try {
@@ -272,6 +331,30 @@ public class FhirSubCmd implements BLauncherCmd {
     /**
      * This util is to get the output Path.
      */
+    private boolean canResolveSpecificationFromRegistry() {
+        if (igName != null && !igName.isEmpty()) {
+            return true;
+        }
+        if (argList != null && !argList.isEmpty()) {
+            return true;
+        }
+        return SpecificationPathResolver.canResolveWithoutLocalSpec(
+                new SpecificationPathResolver.ResolveRequest(
+                        mode,
+                        executionPath.toString(),
+                        null,
+                        igName,
+                        igVersion,
+                        registryUrl,
+                        igCacheDir,
+                        forceIgDownload,
+                        nonInteractive,
+                        null,
+                        IgRegistryConfigLoader.load(),
+                        printStream
+                ));
+    }
+
     private void getTargetOutputPath() {
         targetOutputPath = executionPath;
         if (this.outputPath != null) {

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
@@ -27,16 +27,25 @@ import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
 import io.ballerina.health.cmd.core.utils.ErrorMessages;
 import io.ballerina.health.cmd.core.utils.HealthCmdConstants;
 import io.ballerina.health.cmd.core.utils.HealthCmdUtils;
+import io.ballerina.health.cmd.core.utils.IgModuleNameUtils;
+import io.ballerina.health.cmd.core.utils.SpecificationPathUtils;
 import org.wso2.healthcare.codegen.tool.framework.commons.config.ToolConfig;
 import org.wso2.healthcare.codegen.tool.framework.commons.core.TemplateGenerator;
 import org.wso2.healthcare.codegen.tool.framework.commons.core.Tool;
 import org.wso2.healthcare.codegen.tool.framework.commons.exception.CodeGenException;
 import org.wso2.healthcare.codegen.tool.framework.commons.model.JsonConfigType;
 import org.wso2.healthcare.codegen.tool.framework.fhir.core.FHIRTool;
+import org.wso2.healthcare.fhir.ballerina.packagegen.tool.BallerinaPackageGenTool;
+import org.wso2.healthcare.fhir.ballerina.packagegen.tool.config.BallerinaPackageGenToolConfig;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -49,6 +58,8 @@ public class FhirTemplateGenHandler implements Handler {
     private String packageVersion;
     private String fhirVersion;
     private String dependentPackage;
+    private boolean generateIgModule;
+    private String igModuleName;
 
     private String[] includedProfiles;
     private String[] excludedProfiles;
@@ -83,15 +94,24 @@ public class FhirTemplateGenHandler implements Handler {
         this.orgName = (String) argsMap.get("--org-name");
         this.packageVersion = (String) argsMap.get("--package-version");
         this.dependentPackage = (String) argsMap.get("--dependent-package");
+        boolean explicitDependentPackage = Boolean.TRUE.equals(argsMap.get("--explicit-dependent-package"));
+        this.generateIgModule = !explicitDependentPackage;
+        this.igModuleName = (String) argsMap.get("--ig-module-name");
         this.includedProfiles = (String[]) argsMap.get("--included-profile");
         this.excludedProfiles = (String[]) argsMap.get("--excluded-profile");
-        this.aggregate = (Boolean) argsMap.get("--aggregate");
+        Object aggregateArg = argsMap.get("--aggregate");
+        this.aggregate = aggregateArg instanceof Boolean ? (Boolean) aggregateArg : true;
         this.minimal = (Boolean) argsMap.get("--minimal");
         this.resources = (String) argsMap.get("--resources");
     }
 
     @Override
     public boolean execute(String specificationPath, String targetOutputPath) {
+        try {
+            applyInternationalBaseDefaults(specificationPath);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to evaluate specification path for template generation", e);
+        }
 
         JsonElement toolExecConfigs = null;
         if (configJson != null) {
@@ -137,35 +157,44 @@ public class FhirTemplateGenHandler implements Handler {
                     JsonElement overrideConfig = new Gson().toJsonTree(fhirVersion.toLowerCase());
                     toolConfigInstance.overrideConfig("project.fhir.default_version", overrideConfig);
                 }
-                if (dependentPackage != null) {
-                    JsonElement overrideConfig = new Gson().toJsonTree(dependentPackage);
-                    JsonElement nameConfig =
-                            new Gson().toJsonTree(dependentPackage.substring(dependentPackage.lastIndexOf('/') + 1));
-                    toolConfigInstance.overrideConfig("project.package.dependentPackage", overrideConfig);
-                    toolConfigInstance.overrideConfig("project.package.namePrefix", nameConfig);
+                if (generateIgModule) {
+                    String resolvedIgModuleName = resolveIgModuleName(specificationPath);
+                    String igModuleSourcePath = generateIgModuleSource(specificationPath, targetOutputPath,
+                            toolExecConfig);
+                    JsonElement generateIgModuleEnabled = new Gson().toJsonTree(true);
+                    JsonElement generateIgModuleNameConfig = new Gson().toJsonTree(resolvedIgModuleName);
+                    JsonElement generateIgModuleSourceDir = new Gson().toJsonTree(igModuleSourcePath);
+                    toolConfigInstance.overrideConfig("project.generateIgModule.enabled", generateIgModuleEnabled);
+                    toolConfigInstance.overrideConfig("project.generateIgModule.name", generateIgModuleNameConfig);
+                    toolConfigInstance.overrideConfig("project.generateIgModule.sourceDir", generateIgModuleSourceDir);
+                } else {
+                    toolConfigInstance.overrideConfig("project.generateIgModule.enabled", new Gson().toJsonTree(false));
+                    if (dependentPackage != null && !dependentPackage.isEmpty()) {
+                        JsonElement overrideConfig = new Gson().toJsonTree(dependentPackage);
+                        JsonElement nameConfig = new Gson().toJsonTree(
+                                dependentPackage.substring(dependentPackage.lastIndexOf('/') + 1));
+                        toolConfigInstance.overrideConfig("project.package.dependentPackage", overrideConfig);
+                        toolConfigInstance.overrideConfig("project.package.namePrefix", nameConfig);
+                    }
                 }
                 toolConfigInstance.overrideConfig("project.package.igConfig", populateIGConfig(
                                 HealthCmdConstants.CMD_DEFAULT_IG_NAME,
                                 orgName,
+                                getEffectiveDependentPackage(),
                                 includedProfiles,
                                 excludedProfiles
                         )
                 );
 
-                // Configure aggregated API settings
-                if (aggregate) {
-                    JsonElement aggregateConfig = new Gson().toJsonTree(true);
-                    toolConfigInstance.overrideConfig("project.enableAggregatedApi", aggregateConfig);
-
-                    if (resources != null && !resources.trim().isEmpty()) {
-                        // Parse comma-separated resources and create JSON array
-                        String[] resourceArray = resources.split(",");
-                        JsonArray resourcesArray = new JsonArray();
-                        for (String resource : resourceArray) {
-                            resourcesArray.add(resource.trim());
-                        }
-                        toolConfigInstance.overrideConfig("project.aggregatedApis", resourcesArray);
+                // Configure aggregated API settings (default: enabled)
+                toolConfigInstance.overrideConfig("project.enableAggregatedApi", new Gson().toJsonTree(aggregate));
+                if (aggregate && resources != null && !resources.trim().isEmpty()) {
+                    String[] resourceArray = resources.split(",");
+                    JsonArray resourcesArray = new JsonArray();
+                    for (String resource : resourceArray) {
+                        resourcesArray.add(resource.trim());
                     }
+                    toolConfigInstance.overrideConfig("project.aggregatedApis", resourcesArray);
                 }
                 // Configure minimal generation settings
                 if (minimal) {
@@ -220,12 +249,121 @@ public class FhirTemplateGenHandler implements Handler {
         return false;
     }
 
-    private JsonObject populateIGConfig(String name, String orgName, String[] includedProfiles,
-                                        String[] excludedProfiles) {
+    private String resolveIgModuleName(String specificationPath) {
+        if (igModuleName != null && !igModuleName.isEmpty()) {
+            return igModuleName;
+        }
+        try {
+            return IgModuleNameUtils.inferIgModuleName(specificationPath);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to infer IG module name from specification", e);
+        }
+    }
+
+    private String generateIgModuleSource(String specificationPath, String targetOutputPath,
+                                          JsonObject toolExecConfig) {
+        try {
+            BallerinaPackageGenToolConfig packageToolConfig = new BallerinaPackageGenToolConfig();
+            String generatedIgPackagePath = Paths.get(targetOutputPath, ".generated-ig-package").toString();
+            Path generatedIgPackagePathObj = Paths.get(generatedIgPackagePath);
+            if (Files.exists(generatedIgPackagePathObj)) {
+                deleteRecursively(generatedIgPackagePathObj.toFile());
+            }
+            packageToolConfig.setTargetDir(generatedIgPackagePath);
+            packageToolConfig.setToolName(HealthCmdConstants.CMD_MODE_PACKAGE);
+            JsonObject packageExecConfig = configJson.getAsJsonObject("fhir").getAsJsonObject("tools")
+                    .getAsJsonObject(HealthCmdConstants.CMD_MODE_PACKAGE).getAsJsonObject("config");
+            packageToolConfig.configure(new JsonConfigType(packageExecConfig));
+
+            String packageNameToGenerate = getPackageNameForIgModule(packageExecConfig);
+            packageToolConfig.overrideConfig("packageConfig.name", new Gson().toJsonTree(packageNameToGenerate));
+            if (orgName != null && !orgName.isEmpty()) {
+                packageToolConfig.overrideConfig("packageConfig.org", new Gson().toJsonTree(orgName.toLowerCase()));
+            }
+            if (packageVersion != null && !packageVersion.isEmpty()) {
+                packageToolConfig.overrideConfig("packageConfig.packageVersion",
+                        new Gson().toJsonTree(packageVersion.toLowerCase()));
+            }
+            if (fhirVersion != null && !fhirVersion.isEmpty()) {
+                packageToolConfig.overrideConfig("packageConfig.fhirVersion", new Gson().toJsonTree(fhirVersion));
+            }
+
+            Tool packageTool = new BallerinaPackageGenTool();
+            packageTool.initialize(packageToolConfig);
+            TemplateGenerator packageTemplateGenerator = packageTool.execute(fhirToolLib.getToolContext());
+            if (packageTemplateGenerator != null) {
+                packageTemplateGenerator.generate(
+                        fhirToolLib.getToolContext(), packageTemplateGenerator.getGeneratorProperties());
+                HealthCmdUtils.engageChildTemplateGenerators(
+                        packageTemplateGenerator.getChildTemplateGenerator(),
+                        fhirToolLib.getToolContext(), packageTemplateGenerator.getGeneratorProperties());
+            }
+            return Paths.get(generatedIgPackagePath, packageNameToGenerate).toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Error generating IG module source package", e);
+        }
+    }
+
+    private String getPackageNameForIgModule(JsonObject packageExecConfigObj) {
+        if (packageName != null && !packageName.isEmpty()) {
+            return packageName;
+        }
+        if (dependentPackage != null && dependentPackage.contains("/")) {
+            return dependentPackage.substring(dependentPackage.lastIndexOf('/') + 1);
+        }
+        return packageExecConfigObj.getAsJsonObject("packageConfigs").getAsJsonPrimitive("name").getAsString();
+    }
+
+    private void deleteRecursively(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        if (!file.delete()) {
+            throw new RuntimeException("Failed to delete file: " + file.getAbsolutePath());
+        }
+    }
+
+    private void applyInternationalBaseDefaults(String specificationPath) throws IOException {
+        boolean useInternationalBase = SpecificationPathUtils.isInternationalBaseSpecification(specificationPath);
+        if ((dependentPackage == null || dependentPackage.isEmpty()) && useInternationalBase) {
+            dependentPackage = getDefaultDependentPackageForFhirVersion();
+            printStream.println(HealthCmdConstants.PrintStrings.USING_INTERNATIONAL_BASE + dependentPackage + ".");
+        }
+        if (generateIgModule && useInternationalBase) {
+            generateIgModule = false;
+            printStream.println("[INFO] International base structure definitions detected. "
+                    + "Using published dependent package " + dependentPackage + " instead of embedding an IG module.");
+        }
+    }
+
+    private String getDefaultDependentPackageForFhirVersion() {
+        if (fhirVersion != null && fhirVersion.equalsIgnoreCase("r5")) {
+            return HealthCmdConstants.CMD_DEFAULT_R5_DEPENDENT_PACKAGE;
+        }
+        return HealthCmdConstants.CMD_DEFAULT_R4_DEPENDENT_PACKAGE;
+    }
+
+    private String getEffectiveDependentPackage() {
+        if (dependentPackage != null && !dependentPackage.isEmpty()) {
+            return dependentPackage;
+        }
+        return getDefaultDependentPackageForFhirVersion();
+    }
+
+    private JsonObject populateIGConfig(String name, String orgName, String dependentPackageName,
+                                        String[] includedProfiles, String[] excludedProfiles) {
 
         JsonObject igConfig = new JsonObject();
         igConfig.addProperty("implementationGuide", name);
-        String importStatement = orgName != null ? orgName : HealthCmdConstants.CMD_DEFAULT_ORG_NAME + "/" + name;
+        String importStatement = dependentPackageName;
+        if (orgName != null && !orgName.isEmpty() && !dependentPackageName.contains("/")) {
+            importStatement = orgName + "/" + dependentPackageName;
+        }
         igConfig.addProperty("importStatement", importStatement);
         igConfig.addProperty("enable", true);
         JsonArray includedProfilesArray = new JsonArray();

--- a/native/health-cli/src/main/resources/ballerina-health.help
+++ b/native/health-cli/src/main/resources/ballerina-health.help
@@ -1,25 +1,52 @@
 NAME
         ballerina-health - Generate a Ballerina package or template for a
-        given health specification (eg.:FHIR implementation guides) files.
+        given health specification (eg.: FHIR implementation guides) files.
 
 SYNOPSIS
         bal health fhir [-m | --mode] package --package-name <package-name> \
-                        <FHIR-specification-directory-path>
-                        [-m | --mode] template --dependent-package <dependent-package> \
-                        <FHIR-specification-directory-path>
-                        [-m | --mode] connector --config <config-file-path> \
-                        --output <output>
+                        [--ig-name <registry-package-id>] [--ig-version <version>] \
+                        [-o <output>] [<FHIR-specification-directory-path>]
+
+        bal health fhir [-m | --mode] template \
+                        [--ig-name <registry-package-id>] [--ig-version <version>] \
+                        [--dependent-package <qualified-ballerina-package-name>] \
+                        [--aggregate <true|false>] [-o <output>] \
+                        [<FHIR-specification-directory-path>]
+
+        bal health fhir [-m | --mode] connector --config <config-file-path> \
+                        -o <output>
 
 
 DESCRIPTION
         Generate a Ballerina package or template with relevant records and types
-        from a given health specification (eg.:FHIR implementation guides) files.
+        from a given health specification (eg.: FHIR implementation guides) files.
 
-        The generated Ballerina sources will be written into the provided
-        output location. Make sure to add the directory path which contains
-        FHIR specification, as the last argument.
+        The generated Ballerina sources are written to the output location given
+        with -o/--output, or to the current working directory when omitted.
 
-        You can download FHIR specification files from the respective
+        FHIR specification files can be provided as a local directory path (last
+        positional argument), or downloaded automatically from the FHIR package
+        registry (https://packages.fhir.org) using --ig-name and --ig-version.
+        The specification path is optional when --ig-name is set, or in template
+        mode when the default HL7 R4 core IG should be used.
+
+        Template mode defaults:
+            - A single aggregated FHIR API under fhir-service/ (--aggregate
+              defaults to true; use --aggregate false for one service per resource).
+            - IG profile types are embedded in a local Ballerina module under
+              fhir-service/modules/<ig-module>/ (inferred from the IG name unless
+              --ig-module-name is set). Pass --dependent-package to import a
+              published package instead and skip local IG module generation.
+
+        When no path or --ig-name is given in template mode, the tool downloads
+        hl7.fhir.r4.core into spec/international and imports the published
+        ballerinax/health.fhir.r4.international401 package (no local IG module).
+
+        When --ig-version is omitted for a registry download, the CLI lists
+        published versions interactively (TTY). Use --non-interactive in CI or
+        scripts to select dist-tags.latest automatically.
+
+        You can also obtain FHIR specification files from the respective
         Implementation Guide's official website. (Published list of
         Implementation Guides can be found in http://fhir.org/guides/registry/)
 
@@ -39,83 +66,112 @@ COMMANDS
 
             OPTIONS
                     -m, --mode <mode-type>
-                        Mode can be 'package' or 'template' or 'connector'.
-				        If the mode is set to 'package',a Ballerina package will be
-				        generated including all the records and types. If the mode is set to
-				        ‘template’, tool will generate Ballerina templates for each FHIR
-				        resource definition available in the specified path. If the mode is
-				        set to ‘connector’, a Ballerina based FHIR connector client will be
-				        generated for a given FHIR server based on its Capability Statement.
-				        This is a MANDATORY input for fhir command.
+                        Mode can be 'package', 'template', or 'connector'.
+                        In 'package' mode, a Ballerina package is generated
+                        with all records and types for the IG. In 'template'
+                        mode, Ballerina FHIR API templates are generated (by
+                        default one aggregated service under fhir-service/).
+                        In 'connector' mode, a Ballerina FHIR connector client
+                        is generated from a server's Capability Statement.
+                        This is a MANDATORY input for the fhir command.
 
                     --package-name <name-of-package>
-                        Only applicable in ‘package’ mode. Name of the Ballerina package
-                        to be generated. This is a MANDATORY input in ‘package’ mode.
+                        Only applicable in 'package' mode. Name of the Ballerina
+                        package to be generated. MANDATORY in 'package' mode.
                         Refer https://ballerina.io/learn/package-references/#the-name-field
 
                     --dependent-ig <base-url-of-the-IG>=<qualified-ballerina-package-name>
-                       This option is only applicable in ‘package’ mode and can accept multiple values.
-                       Each value must be provided as a key-value pair, where:
-                           1. <base-url-of-the-IG> is the base URL of the dependent IG.
-                           2. <qualified-ballerina-package-name> is the fully qualified name of the corresponding dependent Ballerina package.
-                           This is an optional input.
+                        Only applicable in 'package' mode; accepts multiple values.
+                        Each value is a key-value pair where:
+                            1. <base-url-of-the-IG> is the base URL of the dependent IG.
+                            2. <qualified-ballerina-package-name> is the fully qualified
+                               name of the corresponding dependent Ballerina package.
 
-                       For example, if your profile depends on the US Core profile, you should specify it like this:
-                       <base-url-of-the-IG>=<full-qualified-name-of-ballerina-package>
-                       http://hl7.org/fhir/us/core/=ballerinax/health.fhir.r4.uscore501
+                        For example, if your profile depends on US Core:
+                        http://hl7.org/fhir/us/core/=ballerinax/health.fhir.r4.uscore501
 
                     --dependent-package <qualified-ballerina-package-name>
-                        Only applicable in ‘template’ mode. Fully qualified name of the
-                        published Ballerina package containing IG resources
-                        [eg: <org>/<package>]. This option can be used to generate
-                        templates specifically for the resources in the given IG. The
-                        package name part of this value will be added as a prefix to the
-                        template name. This is a MANDATORY input in ‘template’ mode.
+                        Only applicable in 'template' mode. Import an existing
+                        published IG package (eg: <org>/<package>) instead of
+                        embedding IG resources in a local module. Disables
+                        local IG module generation. The package name is used as
+                        a prefix on generated template imports. When omitted,
+                        profile types are embedded under fhir-service/modules/.
+
+                    --ig-name <registry-package-id>
+                        FHIR package registry id (e.g. hl7.fhir.us.core).
+                        Downloads from packages.fhir.org into spec/<ig-name>
+                        when no local specification path is provided. Works in
+                        both 'package' and 'template' modes.
+
+                    --ig-version <version>
+                        Registry package version (e.g. 6.1.0 or 9.0.0). If
+                        omitted, an interactive list of published versions is
+                        shown (TTY). Use --non-interactive for dist-tags.latest.
+
+                    --non-interactive
+                        When --ig-version is omitted, use dist-tags.latest from
+                        registry metadata without prompting (for CI and scripts).
+
+                    --registry-url <url>
+                        FHIR package registry base URL (default:
+                        https://packages.fhir.org).
+
+                    --ig-cache-dir <path>
+                        Directory for cached .tgz downloads (default:
+                        .fhir-ig-cache under the working directory).
+
+                    --force-ig-download
+                        Re-download and re-extract the IG even if definitions
+                        already exist locally.
+
+                    --ig-module-name <name>
+                        Template mode only. Ballerina module name for embedded
+                        IG resources (default: inferred from the IG). Ignored
+                        when --dependent-package is set.
 
                     -o, --output <output>
-                        Location of the generated Ballerina artifacts. If this
-                        path is not specified, the output will be written to
-                        the same directory from which the command is run.
+                        Location of the generated Ballerina artifacts. If
+                        omitted, output is written to the current directory.
 
                     --org-name <org-name-of-the-package>
-                        Organization name of the Ballerina package/template to be generated.
-                        Refer https://ballerina.io/learn/package-references/#the-org-field
+                        Organization name of the generated Ballerina package or
+                        template. Refer
+                        https://ballerina.io/learn/package-references/#the-org-field
 
                     --package-version <version-of-the-package>
-                        Version of the Ballerina package/template to be generated.
+                        Version of the generated Ballerina package or template.
                         Refer https://semver.org/
 
                     --included-profile <profiles-to-included>
-                        Only applicable in ‘template’ mode. If only a specific profile/s
-                        needs to be generated as templates, specify the profile URL as the
-                        value of this parameter. This argument can be used more than once.
+                        Template mode only. Generate templates only for the
+                        given profile URL(s). May be repeated.
 
                     --excluded-profile <profiles-to-excluded>
-                        Only applicable in ‘template’ mode. If only a specific profile/s
-                        needs to be skipped when generating templates, specify the
-                        profile URL as the value of this parameter. This argument
-                        can be used more than once.
+                        Template mode only. Skip the given profile URL(s) when
+                        generating templates. May be repeated.
 
-                    --aggregate
-                        Only applicable in ‘template’ mode. Enable aggregated API mode to generate
-                        a single service with multiple FHIR resources instead of individual
-                        services for each resource.
+                    --aggregate <true|false>
+                        Template mode only. Aggregated API mode (default: true).
+                        When true, generates a single fhir-service with all
+                        resources. Set to false for one service per FHIR resource,
+                        e.g. --aggregate false.
 
                     --resources <resource1,resource2,...>
-                        Only applicable in ‘template’ mode when --aggregate is used. Comma-separated
-                        list of FHIR resources to include in the aggregated service. If not specified,
-                        all available resources will be included. Example: Patient,Observation,Encounter
+                        Template mode only when aggregation is enabled.
+                        Comma-separated list of FHIR resources to include in the
+                        aggregated service. If omitted, all available resources
+                        are included. Example: Patient,Observation,Encounter
 
                     --minimal
-                        Only applicable in 'template' mode. This flag is intended only to be used by
-                        the Health Tool MCP to generate only the core service files without
-                        additional metadata or project structure files.
+                        Template mode only. Intended for the Health Tool MCP.
+                        Generates only core service files and skips .choreo,
+                        OAS, .gitignore, and Ballerina.toml.
 
                     -c, --config <config-file-path>
-                    	This is a MANDATORY input applicable in ‘connector’ mode. Provide the path
-                    	for the configuration json file containing the necessary parameters to run the
-                    	tool in connector mode including Capability Statement URL of the FHIR server.
-                    	Sample json configuration:
+                        MANDATORY in 'connector' mode. Path to the configuration
+                        JSON file including the FHIR server Capability Statement
+                        URL. Sample configuration:
                         {
                           "config": {
                             "fhirServerUrl": "<capability-statement-url>",
@@ -131,19 +187,46 @@ COMMANDS
 
 
             EXAMPLES
-                    Generate a Ballerina package for the FHIR artifacts of USCore
-                    implementation guide.
-                        $ bal health fhir -m package --package-name uscore401 \
-                        ./path_to_uscore_definitions
+                    Generate templates from the default HL7 R4 core IG (registry
+                    download; imports ballerinax/health.fhir.r4.international401).
+                        $ bal health fhir -m template -o ./generated-template
 
-                    Generate a Ballerina package for the FHIR artifacts of
-                    USCore implementation guide and write the output
-                    to the given directory.
-                        $ bal health fhir -m package --package-name uscore401 \
-                        -o ./output_path ./path_to_uscore_definitions
+                    Generate templates from US Core via the registry (embedded IG
+                    module, aggregated service; pick version interactively).
+                        $ bal health fhir -m template --ig-name hl7.fhir.us.core \
+                        -o ./generated-template
 
-                    Generate Ballerina templates for all the FHIR resource profiles
-                    of USCore implementation guide.
+                    Pin a US Core registry version (non-interactive CI example).
+                        $ bal health fhir -m template --ig-name hl7.fhir.us.core \
+                        --ig-version 9.0.0 --non-interactive -o ./generated-template
+
+                    Generate templates using a published US Core package instead
+                    of an embedded local module.
                         $ bal health fhir -m template \
                         --dependent-package ballerinax/health.fhir.r4.uscore501 \
+                        --ig-name hl7.fhir.us.core --ig-version 6.1.0 \
+                        -o ./generated-template
+
+                    Generate separate services per FHIR resource.
+                        $ bal health fhir -m template --ig-name hl7.fhir.us.core \
+                        --aggregate false -o ./generated-template
+
+                    Generate a Ballerina package from local US Core definitions.
+                        $ bal health fhir -m package --package-name uscore401 \
                         ./path_to_uscore_definitions
+
+                    Generate a package from US Core via the FHIR package registry.
+                        $ bal health fhir -m package --package-name uscore501 \
+                        --org-name ballerinax --ig-name hl7.fhir.us.core \
+                        --ig-version 6.1.0 -o ./output
+
+                    Generate templates from local US Core definitions (embedded
+                    IG module by default).
+                        $ bal health fhir -m template \
+                        -o ./generated-template ./path_to_uscore_definitions
+
+                    Generate templates from local definitions using a published
+                    US Core package.
+                        $ bal health fhir -m template \
+                        --dependent-package ballerinax/health.fhir.r4.uscore501 \
+                        -o ./generated-template ./path_to_uscore_definitions

--- a/native/health-cli/src/main/resources/tool-config.json
+++ b/native/health-cli/src/main/resources/tool-config.json
@@ -1,5 +1,23 @@
 {
   "fhir": {
+    "igRegistry": {
+      "registryUrl": "https://packages.fhir.org",
+      "cacheDir": ".fhir-ig-cache",
+      "httpTimeoutSeconds": 60,
+      "defaultPackages": {
+        "r4": {
+          "name": "hl7.fhir.r4.core",
+          "version": "4.0.1"
+        },
+        "r5": {
+          "name": "hl7.fhir.r5.core",
+          "version": "5.0.0"
+        }
+      },
+      "packageMappings": {
+        "hl7.fhir.us.core": "ballerinax/health.fhir.r4.uscore501"
+      }
+    },
     "tools": {
       "package": {
         "config": {
@@ -69,10 +87,14 @@
             ]
           },
           "dependencies": [],
-          "enableAggregatedApi": false,
+          "enableAggregatedApi": true,
           "minimalGeneration": false,
           "aggregatedApis": [
           ],
+          "generateIgModule": {
+            "enabled": true,
+            "name": ""
+          },
           "builtIn": {
             "operations": [
             ],

--- a/native/health-cli/src/test/java/LocalModuleTemplateTestRunner.java
+++ b/native/health-cli/src/test/java/LocalModuleTemplateTestRunner.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import io.ballerina.cli.launcher.BLauncherException;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+import io.ballerina.health.cmd.core.utils.HealthCmdUtils;
+import io.ballerina.health.cmd.handler.Handler;
+import io.ballerina.health.cmd.handler.HandlerFactory;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Runner that validates default embedded IG module template generation.
+ */
+public class LocalModuleTemplateTestRunner {
+
+    private static final Path EXECUTION_PATH = Paths.get(System.getProperty("user.dir"));
+
+    public static void main(String[] args) throws Exception {
+        runLocalModuleTemplateGenerationTest();
+    }
+
+    private static void runLocalModuleTemplateGenerationTest() throws URISyntaxException, BallerinaHealthException {
+        Map<String, Object> argsMap = new HashMap<>();
+        argsMap.put("--package-name", "uscore501");
+        argsMap.put("--org-name", "ballerinax");
+        argsMap.put("--package-version", "1.1.0");
+        argsMap.put("--included-profile", null);
+        argsMap.put("--excluded-profile", null);
+        argsMap.put("--explicit-dependent-package", false);
+        argsMap.put("--dependent-package", null);
+        argsMap.put("--ig-module-name", "localprofile");
+        argsMap.put("--dependent-ig", null);
+        argsMap.put("--aggregate", true);
+        argsMap.put("--resources", "Patient");
+        argsMap.put("--minimal", false);
+
+        String mode = "template";
+        String command = "fhir";
+
+        String resourcePath = Paths.get(
+                Objects.requireNonNull(LocalModuleTemplateTestRunner.class.getClassLoader().getResource("io")).toURI()
+        ).getParent().getParent().toString() + File.separator + "test-classes" + File.separator + "profiles.USCore";
+        Path specificationPath = HealthCmdUtils.validateAndSetSpecificationPath(resourcePath, EXECUTION_PATH.toString());
+        Path outputPath = Paths.get(resourcePath).getParent().resolve("local-module-template-test");
+        cleanOutputDirectory(outputPath);
+
+        Handler toolHandler;
+        try {
+            toolHandler = HandlerFactory.createHandler(command, mode, System.out, specificationPath.toString());
+        } catch (BallerinaHealthException e) {
+            throw new BLauncherException();
+        }
+        toolHandler.setArgs(argsMap);
+        boolean executionStatus = toolHandler.execute(specificationPath.toString(), outputPath.toString());
+        if (!executionStatus) {
+            throw new RuntimeException("Local module template generation failed");
+        }
+
+        Path servicePath = outputPath.resolve("fhir-service").resolve("service.bal");
+        Path localModuleInitializerPath = outputPath.resolve("fhir-service")
+                .resolve("modules")
+                .resolve("localprofile")
+                .resolve("initializer.bal");
+
+        if (!Files.exists(servicePath)) {
+            throw new RuntimeException("Generated aggregated service not found: " + servicePath);
+        }
+        if (!Files.exists(localModuleInitializerPath)) {
+            throw new RuntimeException("Generated IG module not found: " + localModuleInitializerPath);
+        }
+
+        try {
+            String serviceContent = Files.readString(servicePath);
+            if (!serviceContent.contains("localprofile:")) {
+                throw new RuntimeException("Generated service does not use generated IG module imports");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed validating generated service content", e);
+        }
+    }
+
+    private static void cleanOutputDirectory(Path outputPath) {
+        File file = outputPath.toFile();
+        if (!file.exists()) {
+            return;
+        }
+        delete(file);
+    }
+
+    private static void delete(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    delete(child);
+                }
+            }
+        }
+        if (!file.delete()) {
+            throw new RuntimeException("Failed to delete test artifact: " + file.getAbsolutePath());
+        }
+    }
+}

--- a/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/CommonUtilTest.java
+++ b/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/CommonUtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import org.junit.jupiter.api.Test;
+import org.wso2.healthcare.fhir.ballerina.packagegen.tool.utils.GeneratorUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CommonUtilTest {
+
+    @Test
+    void stripCanonicalVersionRemovesVersionSuffix() {
+        assertEquals("http://hl7.org/fhir/StructureDefinition/SimpleQuantity",
+                org.wso2.healthcare.fhir.ballerina.packagegen.tool.utils.CommonUtil.stripCanonicalVersion(
+                        "http://hl7.org/fhir/StructureDefinition/SimpleQuantity|4.0.1"));
+    }
+
+    @Test
+    void getUniqueIdentifierFromVersionedProfileTypeDoesNotProduceDots() {
+        assertEquals("SimpleQuantity",
+                GeneratorUtils.getInstance().getUniqueIdentifierFromId("SimpleQuantity|4.0.1"));
+    }
+}

--- a/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloaderTest.java
+++ b/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloaderTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FhirIgPackageDownloaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void extractPackageWritesStructureDefinitionJson() throws Exception {
+        byte[] tgz = buildSamplePackageTgz();
+        Path target = tempDir.resolve("extracted");
+        FhirIgPackageDownloader.extractPackage(tgz, target);
+
+        Path patientSd = target.resolve("StructureDefinition-Patient.json");
+        assertTrue(Files.exists(patientSd));
+        String content = Files.readString(patientSd);
+        assertTrue(content.contains("\"resourceType\": \"StructureDefinition\""));
+        assertTrue(SpecificationPathUtils.containsStructureDefinitionResources(target));
+    }
+
+    @Test
+    void downloadAndExtractSkipsWhenDefinitionsPresent() throws Exception {
+        Path target = tempDir.resolve("cached-ig");
+        Files.createDirectories(target);
+        Files.writeString(target.resolve("StructureDefinition-Patient.json"), """
+                {
+                  "resourceType": "StructureDefinition",
+                  "url": "http://hl7.org/fhir/StructureDefinition/Patient",
+                  "name": "Patient",
+                  "type": "Patient",
+                  "kind": "resource",
+                  "fhirVersion": "4.0.1"
+                }
+                """);
+
+        FhirIgPackageDownloader.DownloadOptions options = new FhirIgPackageDownloader.DownloadOptions(
+                "https://packages.fhir.org", tempDir.resolve("cache").toString(), 60, false);
+        Path result = FhirIgPackageDownloader.downloadAndExtract(
+                target, "hl7.fhir.r4.core", "4.0.1", options);
+        assertEquals(target, result);
+    }
+
+    @Test
+    void parseIgSpecUsesLatestSentinelWhenVersionMissing() {
+        FhirIgPackageDownloader.ParsedIgSpec spec =
+                FhirIgPackageDownloader.parseIgSpec("hl7.fhir.us.core", null);
+        assertEquals("hl7.fhir.us.core", spec.name());
+        assertEquals("latest", spec.version());
+    }
+
+    @Test
+    void parseLatestVersionFromMetadata() throws Exception {
+        String metadata = """
+                {
+                  "name": "hl7.fhir.us.core",
+                  "dist-tags": { "latest": "9.0.0" }
+                }
+                """;
+        assertEquals("9.0.0",
+                FhirIgPackageDownloader.parseLatestVersionFromMetadata(metadata, "hl7.fhir.us.core"));
+    }
+
+    @Test
+    void parseLatestVersionFromMetadataMissingDistTags() {
+        assertThrows(BallerinaHealthException.class, () ->
+                FhirIgPackageDownloader.parseLatestVersionFromMetadata("{\"name\":\"x\"}", "x"));
+    }
+
+    @Test
+    void resolvePackageVersionKeepsExplicitVersion() throws Exception {
+        FhirIgPackageDownloader.DownloadOptions options = new FhirIgPackageDownloader.DownloadOptions(
+                "https://packages.fhir.org", tempDir.resolve("cache").toString(), 60, false, true, null);
+        assertEquals("6.1.0", FhirIgPackageDownloader.resolvePackageVersion(
+                "https://packages.fhir.org", "hl7.fhir.us.core", "6.1.0", options));
+    }
+
+    @Test
+    void sanitizeIgDirectoryName() {
+        assertEquals("hl7_fhir_us_core", FhirIgPackageDownloader.sanitizeIgDirectoryName("hl7.fhir.us.core"));
+    }
+
+    private static byte[] buildSamplePackageTgz() throws IOException {
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzipOut = new GZIPOutputStream(byteOut);
+             TarArchiveOutputStream tarOut = new TarArchiveOutputStream(gzipOut)) {
+            addTarEntry(tarOut, "package/package.json", """
+                    {"name":"test.package","version":"1.0.0","fhirVersions":["4.0.1"]}
+                    """);
+            addTarEntry(tarOut, "package/StructureDefinition-Patient.json", """
+                    {
+                      "resourceType": "StructureDefinition",
+                      "url": "http://hl7.org/fhir/StructureDefinition/Patient",
+                      "name": "Patient",
+                      "type": "Patient",
+                      "kind": "resource",
+                      "fhirVersion": "4.0.1"
+                    }
+                    """);
+            tarOut.finish();
+        }
+        return byteOut.toByteArray();
+    }
+
+    private static void addTarEntry(TarArchiveOutputStream tarOut, String name, String content) throws IOException {
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        TarArchiveEntry entry = new TarArchiveEntry(name);
+        entry.setSize(bytes.length);
+        tarOut.putArchiveEntry(entry);
+        tarOut.write(bytes);
+        tarOut.closeArchiveEntry();
+    }
+}

--- a/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/IgVersionSelectorTest.java
+++ b/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/IgVersionSelectorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IgVersionSelectorTest {
+
+    private static final String US_CORE_METADATA = """
+            {
+              "name": "hl7.fhir.us.core",
+              "dist-tags": { "latest": "9.0.0" },
+              "versions": {
+                "6.1.0": { "fhirVersion": "4.0.1" },
+                "9.0.0": { "fhirVersion": "4.0.1" },
+                "9.0.0-ballot": { "fhirVersion": "4.0.1" }
+              }
+            }
+            """;
+
+    @Test
+    void parseAvailableVersionsReturnsNewestFirst() throws Exception {
+        List<String> versions = IgVersionSelector.parseAvailableVersions(US_CORE_METADATA);
+        assertEquals(3, versions.size());
+        assertEquals("9.0.0", versions.get(0));
+        assertTrue(versions.contains("6.1.0"));
+    }
+
+    @Test
+    void selectVersionNonInteractiveUsesLatestTag() throws Exception {
+        List<String> versions = IgVersionSelector.parseAvailableVersions(US_CORE_METADATA);
+        String selected = IgVersionSelector.selectVersion(
+                "hl7.fhir.us.core", versions, "9.0.0", true, null);
+        assertEquals("9.0.0", selected);
+    }
+
+    @Test
+    void selectVersionNonInteractiveFallsBackToFirstWhenLatestMissing() throws Exception {
+        List<String> versions = List.of("6.1.0", "5.0.0");
+        String selected = IgVersionSelector.selectVersion(
+                "hl7.fhir.us.core", versions, null, true, null);
+        assertEquals("6.1.0", selected);
+    }
+
+    @Test
+    void compareVersionsOrdersNumericSegments() {
+        assertTrue(IgVersionSelector.compareVersionsDesc("9.0.0", "6.1.0") < 0);
+        assertTrue(IgVersionSelector.compareVersionsDesc("9.0.0-ballot", "9.0.0") > 0);
+    }
+
+    @Test
+    void selectVersionNonInteractiveDoesNotWritePrompt() throws Exception {
+        List<String> versions = IgVersionSelector.parseAvailableVersions(US_CORE_METADATA);
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        PrintStream capture = new PrintStream(buffer);
+        IgVersionSelector.selectVersion("hl7.fhir.us.core", versions, "9.0.0", true, capture);
+        assertEquals(0, buffer.size());
+    }
+
+    @Test
+    void isInteractiveConsoleUnavailableInJUnit() {
+        assertFalse(IgVersionSelector.isInteractiveConsoleAvailable());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>io.ballerina</groupId>
     <artifactId>health-tools</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <packaging>pom</packaging>
     <modules>


### PR DESCRIPTION
## Purpose
> $Subject. Following are the detailed changes
> - Download IGs from packages.fhir.org (--ig-name/--ig-version), with interactive version selection (or --non-interactive for dist-tags.latest)
> - Default template mode to aggregated fhir-service and embedded IG module; use --dependent-package to import a published package, --aggregate false for separate services
> - Fix versioned canonical profile URLs (e.g. SimpleQuantity|4.0.1) that produced invalid Ballerina types
> - Bump health tool release to 4.0.0 for breaking CLI/default behavior changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added FHIR Implementation Guide registry integration with version resolution, caching, extraction, interactive selection, and non-interactive support.
- Updated FHIR CLI and MCP workflows to accept registry-based specifications, optional local paths, dependent packages, and aggregation controls.
- Made aggregated `fhir-service` template generation the default, with optional embedded IG modules and improved module-name inference.
- Fixed handling of versioned canonical profile URLs, including identifiers such as `SimpleQuantity|4.0.1`.
- Expanded CLI documentation, configuration, validation, and automated coverage for registry downloads and template generation.
- Bumped the health tooling release and Maven modules to version 4.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->