### PR TITLE
Improve FHIR IG registry downloads and template generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ hs_err_pid*
 replay_pid*
 **/target/*
 .idea
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.mypy_cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,3 +235,51 @@ bal build             # the real check: Velocity syntax errors and the compiler-
 To revert to whichever `health` version was active before testing: `bal tool remove health:<version>
 --repository=local` (not `bal tool pull <old-version>` — pulling a version that's already cached locally does
 *not* reactivate it; removing the active version falls back to the next installed one automatically).
+
+## Known limitation: no multi-IG generation
+
+A real, validated requirement (confirmed against two independent hand-written services, `OrganizationService` and
+`PractitionerService`, in a real facade project) is generating a *single* resource type — e.g. `Organization` or
+`Practitioner` — whose profiles come from **two different IGs** (e.g. CARIN BB's `C4BBOrganization` and Da Vinci
+PDex Plan-Net's `PlannetOrganization`/`PlannetNetwork`), dispatched by `_profile` exactly like the multi-profile
+case above. **This is not possible today.** Three concrete reasons, not just "no flag for it yet":
+
+1. `--ig` accepts exactly one value per invocation — there is no repeatable `--ig`.
+2. Running the tool twice against the same `-o` doesn't merge — `serviceMap` (where profiles accumulate per
+   resource type, see above) is rebuilt from scratch in-memory every invocation and never persisted, so a second
+   run would overwrite the first run's `Organization`/`Practitioner` output, not add to it.
+3. `IncludedIGConfig` is always keyed to the literal constant `"FHIR"` (see `FhirTemplateGenHandler`'s
+   `populateIGConfig()`/`HealthCmdConstants.CMD_DEFAULT_IG_NAME`), not the real IG name — the plumbing between the
+   CLI and the codegen engine is single-IG-shaped end to end, even though `BallerinaProjectToolConfig` itself has
+   an unused `populateIgConfigs(JsonArray)` path reading a static `"includedIGs"` array that was clearly built
+   with multiple IGs in mind.
+
+**The good part: the dispatch-skeleton generation is profile-driven, not IG-driven** — `addResourceProfile()`
+doesn't care which IG a profile came from, and the union-type-alias + per-profile `search<ProfileName>` stub +
+`match _profile` mechanism (see above) would produce the exact right shape for a merged multi-IG resource type
+*without any changes*, if only it were fed profiles from more than one IG in a single run. The missing piece is
+narrower than a redesign: make `--ig` repeatable, resolve each into its own `spec/<name>/` (existing machinery,
+no new download logic needed), and feed every resolved IG's StructureDefinitions through the same
+`addResourceProfile()` pass tagged with its real IG name instead of the `"FHIR"` constant.
+
+This is coupled to the `packageMappings` auto-apply question directly below: without an auto-applying, accurate
+mapping, a multi-IG generation would embed *every* IG as a separate local module by default, even for IGs with a
+known-correct published package already available.
+
+## `packageMappings` (`tool-config.json`'s `fhir.igRegistry.packageMappings`): still name-only in code
+
+Despite being discussed at length and having confirmed, version-pinned mappings ready, **the code has not been
+updated yet** — don't assume adding entries to `tool-config.json` is sufficient on its own:
+
+- `IgRegistryConfig.resolveDependentPackage(String igName)` still looks up by bare IG name only. Adding a
+  version-suffixed key like `"hl7.fhir.us.carin-bb.r4@2.1.0"` to the JSON will silently never match anything
+  until this is changed to `resolveDependentPackage(igName, igVersion)`, keyed by `igName + "@" + igVersion`
+  (matching `--ig`'s own npm-style grammar) — the fix is small and does not depend on the open question below.
+- Whether an exact match should **auto-apply** `--dependent-package` (like the international-base-detection path
+  already does silently) or remain **advisory-only** (today's behavior — an `[INFO]` suggestion, local embedding
+  still happens by default) is an open decision, not yet made.
+- Confirmed, version-pinned mappings collected so far, not yet added to `tool-config.json`:
+  `hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
+  `hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200`.
+  A package's own version-ish naming suffix does not reliably indicate the IG version it targets — confirm with
+  someone who knows, don't infer from the package name (`carinbb200` targets IG `2.1.0`, not `2.0.0`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,237 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Codex, Cursor, etc.) when working with code in this repository.
+
+## What this repo is
+
+`fhir-tools` builds the **Ballerina Health Tool** (`bal health`) — a `bal` CLI tool for generating Ballerina
+artifacts (packages, service templates, client connectors) from FHIR Implementation Guides (IGs) and CDS Hooks
+definitions. It is a multi-module Maven project (Java 21) whose final output is packaged as a Ballerina tool
+(`health-tool-ballerina`) and published to Ballerina Central. A separate Python MCP server exposes the same
+`bal health` commands as AI-callable tools.
+
+## Prerequisites & one-time setup
+
+- Java 17+ (repo compiles with `maven.compiler.source/target` = 21)
+- Ballerina Swan Lake **2201.12.3** (`bal` must be on `PATH`) — required to run the `bal pack`/`bal test` steps
+  invoked from Maven
+- A GitHub Personal Access Token with read access to GitHub Packages, added to `~/.m2/settings.xml` with server id
+  `ballerina-language-repo` (needed to resolve `ballerina-lang`/`ballerina-cli` artifacts):
+  ```xml
+  <servers>
+      <server>
+          <id>ballerina-language-repo</id>
+          <username>{Github_username}</username>
+          <password>{Github_PAT}</password>
+      </server>
+  </servers>
+  ```
+- The [`wso2/open-healthcare-codegen-tool-framework`](https://github.com/wso2/open-healthcare-codegen-tool-framework)
+  repo (currently pinned to `v2.1.2` via `version.healthcare.tool.framework` in the root `pom.xml`) must be built
+  and `mvn clean install`ed locally first — this repo's modules depend on its `commons`/`fhir-core` artifacts, which
+  are not on Maven Central.
+- If `mvn clean install` fails resolving `org.wso2.healthcare.codegen.tool.framework:*` even after installing the
+  framework above, check `~/.m2/repository/org/wso2/healthcare/codegen/tool/framework/*/*.lastUpdated` — Maven
+  caches a *negative* resolution result there if it ever tried (and failed) to fetch these artifacts remotely
+  before the local install existed. Delete that directory tree and rebuild; these artifacts only ever come from
+  the local install, never from `ballerina-language-repo` or Central.
+
+## Build & test
+
+```shell
+# from repo root, after the codegen-tool-framework has been installed locally
+mvn clean install
+```
+
+This builds every module in the order declared in the root `pom.xml` and finishes by running `bal pack` to produce
+the `health-tool-ballerina` Ballerina package under `ballerina/target/health-tool-ballerina`.
+
+- Build a single module (respecting the reactor for its dependencies): `mvn clean install -pl native/health-cli -am`
+- **Only `native/health-cli` has JUnit coverage** (JUnit 5, added alongside the `--ig` registry-download feature).
+  `fhir-to-bal-template`, `fhir-to-bal-connector`, and `cds-bal-template` have no `src/test` directory and no test
+  dependency at all — see "Verifying template-generation changes" below for how correctness of *those* modules is
+  actually checked.
+- Beyond JUnit, `native/health-cli`'s `packageGenTests` Maven profile (active by default) drives a second,
+  integration-style check via `exec-maven-plugin`:
+  1. `TestRunner.java` (`native/health-cli/src/test/java/TestRunner.java`) invokes the FHIR **package**-gen handler
+     directly (bypassing the CLI/picocli layer) against the bundled fixtures — `profiles.USCore` for FHIR **R4**
+     and `profiles.EuropeBase` for FHIR **R5** (system property `fhirVersion` selects which one runs), plus a CDS
+     template run against `cds.hooks/tool-config.toml`. This never exercises template-mode generation.
+  2. The generated Ballerina packages are then exercised with `bal test` against `.bal` test files copied in from
+     `native/fhir-to-bal-lib/src/test/resources/ballerina.tests/{r4,r5}`.
+  - To iterate on this locally: `mvn test -pl native/health-cli -am`. To change what's exercised, edit the fixtures
+    under `native/health-cli/src/test/resources/profiles.*` or the `.bal` files under
+    `native/fhir-to-bal-lib/src/test/resources/ballerina.tests/`.
+- CI (`.github/workflows/ci.yml`) does the same thing on every PR: checks out this repo plus
+  `open-healthcare-codegen-tool-framework` at the pinned tag, builds the framework, then runs `mvn clean install`
+  on this repo.
+- Release/publish (`.github/workflows/cd.yml`) is a manual `workflow_dispatch` (inputs: `bal_central_environment` =
+  `STAGE`/`DEV`/`PROD`) that runs the same build, then `bal push`es `ballerina/target/health-tool-ballerina` to that
+  Ballerina Central environment. On `PROD` it additionally cuts a GitHub Release tagged from the current `pom.xml`
+  version, bumps the patch version across **all** module `pom.xml` files, and opens a "prepare for next dev cycle"
+  PR back to `main`. This is the only supported publish path — there is no CLI command to unpublish or delete an
+  already-published version, only `bal deprecate <org>/<name>[:<version>]` (reversible with `--undo`; does not
+  delete anything, just discourages future dependency resolution onto it).
+
+### Keeping versions in sync
+
+The version is duplicated across `pom.xml` (root), `ballerina/pom.xml`, and every `native/*/pom.xml`. When bumping
+the version manually, update all of them (see the `sed` list in `cd.yml`'s "Update version in the pom files" step
+for the authoritative file list).
+
+## Architecture
+
+### Module graph (build order, from the root `pom.xml`)
+
+```
+native/fhir-to-bal-template   ─┐
+native/fhir-to-bal-lib         │  independent Java codegen libraries
+native/cds-bal-template        │  (each wraps a Tool from open-healthcare-codegen-tool-framework)
+native/fhir-to-bal-connector  ─┘
+native/health-cli              — CLI entry point; depends on the four modules above at runtime via reflection
+ballerina                      — packages health-cli + all native jars into a `bal tool` distributable
+```
+
+- **`native/fhir-to-bal-lib`** — generates a Ballerina **package** (data types, resources, extensions) from a FHIR
+  IG's `StructureDefinition`/`ValueSet`/`CodeSystem` JSON files. Version-specific logic lives under
+  `packagegen/tool/modelgen/versions/{r4,r5}`; Velocity templates live in `src/main/resources/templates`.
+- **`native/fhir-to-bal-template`** — generates a Ballerina **service template** (FHIR API scaffolding: resource
+  handlers, OpenAPI spec, `Component.yaml`) that depends on a previously generated package (or an IG module
+  embedded locally — see below). Also version-specific under `project/tool/versions/{r4,r5}`; templates in
+  `src/main/resources/template`. See "Working in the Velocity templates" below before editing these.
+- **`native/fhir-to-bal-connector`** — generates a Ballerina **client connector** for a remote FHIR server, driven
+  by that server's `CapabilityStatement` (see `model/CapabilityStatement.java`, `model/ConnectorOperation.java`).
+- **`native/cds-bal-template`** — generates a Ballerina **CDS Hooks** service template from a TOML hook-definitions
+  file (`BallerinaCDSProjectTool`, templates in `src/main/resources/template`). Its `cdsBalService.vm` copyright
+  header is written entirely as `##`-prefixed Velocity comments, so it's stripped at render time — CDS-generated
+  files currently ship with no copyright header at all (a latent bug, not a deliberate omission).
+- **`native/health-cli`** — the actual `bal health` command. `HealthCmd` (picocli root command) dispatches to
+  `FhirSubCmd` / `Hl7SubCmd` / `CdsSubCmd`. Each subcommand resolves a `Handler` via
+  `handler/HandlerFactory.createHandler(subCommand, mode, ...)`, keyed by `"<subcommand>:<mode>"` (e.g.
+  `fhir:package`, `fhir:template`, `fhir:connector`, `cds:template`). Handlers **reflectively load** the
+  corresponding `Tool`/`ToolConfig` classes from the codegen modules above (see the hardcoded class names in
+  `FhirPackageGenHandler`, e.g. `org.wso2....packagegen.tool.BallerinaPackageGenTool`) rather than depending on
+  them at compile time — keep those fully-qualified class name strings in sync if you rename/move classes in the
+  `native/fhir-to-bal-*` modules. Per-mode default configuration (base packages, dependent packages, repository
+  URLs per FHIR version, FHIR-registry defaults, etc.) lives in the JSON resources `tool-config.json` /
+  `cds-tool-config.json` / `connector-tool-config.json` under `native/health-cli/src/main/resources`, and is
+  overridden at runtime by CLI flags via `ToolConfig.overrideConfig(...)`.
+- **`ballerina`** — not a real Ballerina package at rest; `src/main/resources/health-tool-ballerina` is a template
+  that Maven's `maven-antrun-plugin`/`exec-maven-plugin` fill in at `package`/`install` time: it copies all the
+  native jars into `resources/`, generates `BalTool.toml` listing them as dependencies, and runs `bal pack`. This
+  is the artifact that gets `bal push`ed to Ballerina Central.
+- **`mcp/health-tool-mcp`** — standalone Python **FastMCP** server (`server.py`) that shells out to the installed
+  `bal health` CLI and exposes `fhirPackageGeneration`, `fhirTemplateGeneration`, and `cdsTemplateGeneration` as MCP
+  tools for AI clients (e.g. Claude Desktop). It is independent of the Maven build — see
+  `mcp/health-tool-mcp/README.md` for its own setup (`uv sync` / `pip install -r requirements.txt`,
+  `uv run fastmcp run server.py`). Configured via `MCP_WORKSPACE`, `MCP_LOG_DIR`, `MCP_SUBPROCESS_TIMEOUT`,
+  `MCP_MIN_FREE_DISK_MB`, `MCP_CLIENT_NAME` env vars; logs structured JSONL to `$MCP_LOG_DIR/mcp_io.jsonl`. Always
+  passes `--minimal` for template generation, so it's unaffected by `--flat` (see below) — it was already flat.
+
+### `bal health` command surface
+
+```shell
+bal health fhir -m package --package-name my.package.name -o output-dir spec-path
+bal health fhir -m package --package-name my.package.name --ig hl7.fhir.us.core@8.0.1 -o output-dir
+bal health fhir -m template --ig hl7.fhir.us.core -o output-dir
+bal health fhir -m template -o output-dir spec-path
+bal health fhir -m connector --config configuration-file-path -o output-dir
+```
+
+A local `spec-path` and `--ig <name>[@version]` (a registry download — see below) are alternative ways to supply
+FHIR definitions to `package`/`template` mode. A local `spec-path` must contain one subfolder per Implementation
+Guide, each holding that IG's FHIR definition JSON files (`StructureDefinition-*.json`, `ValueSet-*.json`,
+`CodeSystem-*.json`, ...). Real fixtures for this layout live under `native/health-cli/src/test/resources/profiles.*`.
+
+Template mode defaults to a single **aggregated** service (`--aggregate false` for one service per FHIR resource
+instead), written under `<output>/fhir-service/` unless `--flat` is passed (writes directly into `<output>` instead
+— keeps `Ballerina.toml`/`.gitignore`/OAS/`.choreo`, unlike `--minimal`, which also flattens but drops all of
+those). `--package-name` is mandatory in package mode; in aggregated template mode it's optional and names the
+generated project itself (default `FHIRServerTemplate`) — it has no effect with `--aggregate false`.
+
+### FHIR registry downloads (`--ig`)
+
+`--ig <name>[@version]` (npm-style, e.g. `hl7.fhir.us.core@8.0.1`; a bare name resolves to the latest published
+version, auto-selected non-interactively whenever there's no TTY) downloads an Implementation Guide from the FHIR
+package registry (default `https://packages.fhir.org`, override with `--registry-url`) instead of requiring a
+local `spec-path`. Implemented in `FhirIgPackageDownloader` (`native/health-cli/.../core/utils/`) and orchestrated
+by `SpecificationPathResolver.resolve()`.
+
+Two distinct, persistent locations are involved, not one:
+- **`.fhir-ig-cache/<name>-<version>.tgz`** (override with `--ig-cache-dir`) — the raw downloaded archive, cached
+  purely to avoid re-hitting the network on a future run. To pre-seed it yourself, the file must match this exact
+  naming convention; if `--ig-cache-dir` is explicitly set and misses, a `[WARN]` says so before falling back to
+  the network.
+- **`spec/<sanitized-name>/`** — the *extracted* JSON files the codegen framework actually reads (it needs real
+  files on disk, not a `.tgz`). This mirrors the tool's original, pre-registry-download convention of a
+  user-supplied local spec directory, so it's treated as real project content, not disposable cache — unlike
+  `.fhir-ig-cache/`, it is not gitignored automatically.
+
+`downloadAndExtract()` short-circuits (no network, no extraction) if `spec/<name>/` already has valid content —
+*unless* the on-disk `package.json` version doesn't match what was requested, in which case it re-fetches and logs
+why (`FhirIgPackageDownloader.isVersionMismatch()` / `SpecificationPathUtils.readInstalledPackageVersion()`).
+`--force-ig-download` always re-fetches regardless of either check.
+
+`tool-config.json`'s `fhir.igRegistry.packageMappings` can suggest a known published Ballerina package for an
+exact `<ig-name>@<version>` match, but today this is **advisory only** — it prints an `[INFO]` suggestion and
+still embeds the IG locally by default; it does not auto-apply `--dependent-package` the way the
+international-base-detection path does (which *does* silently substitute a published package). Confirmed, correct
+version-pinned mappings collected so far: `hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
+`hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200` — note the package's own version-ish
+naming suffix does *not* reliably indicate the IG version it targets (`carinbb200` ↔ IG `2.1.0`, not `2.0.0`);
+don't infer a mapping from a package name alone.
+
+### Working in the Velocity templates (`fhir-to-bal-template/src/main/resources/template/*.vm`)
+
+Two non-obvious constraints are easy to violate and only surface as errors at `bal build` time on the *generated*
+output, never at `mvn compile` time on the templates themselves:
+
+- **Anything declared inside a `service ... on new Listener(...) { ... }` block is a service member, not a free
+  function.** Calling it by bare name from another function *inside the same block* fails with "undefined
+  function" — Ballerina requires `self.` to reach a service's own members. Helper functions meant to be called
+  from a resource function (e.g. per-profile search stubs) must be declared *outside* the `service { ... }` block,
+  at module level, alongside the type aliases.
+- **`ballerinax/health.fhir.r4` ships its own compiler plugin with FHIR-specific resource-function rules**
+  (diagnostic code `FHIR_103`, distinct from ordinary Ballerina `BCE` errors) — it rejects search parameters
+  declared as ordinary resource-function parameters. Every generated resource function takes only
+  `FHIRContext fhirContext`; any additional search parameter (e.g. `_profile`) must be read from inside the
+  function body via `fhirContext.getRequestSearchParameter("<name>")` (returns
+  `readonly & RequestSearchParameter[]?`; each entry has a plain `.value` string field) — never as a second
+  declared parameter.
+
+`BallerinaService`/`FHIRProfile` (`fhir-to-bal-template/.../model/`) key generation by bare FHIR resource *type*,
+not by profile: when a resource type is profiled more than once — even within a single IG (e.g. US Core's ~26
+profiles of `Observation`) — every profile accumulates onto the *same* `BallerinaService`
+(`R4/R5BallerinaProjectTool.addResourceProfile()`), producing a union type alias. The generated search function
+dispatches across them by `_profile` (per the gotcha above); every other resource function (read-by-id,
+POST/PUT/PATCH/DELETE, history) stays a single generic stub regardless of profile count, since `_profile` is the
+one signal the tool can dispatch on before it has a typed value in hand.
+
+Embedding an IG as a local module (the default in template mode when `--dependent-package` isn't given) works by
+running the **package** generator into a scratch directory, `<output>/.generated-ig-package/`, then copying the
+resulting `.bal` sources into `<output>/modules/<ig-module-name>/`
+(`FhirTemplateGenHandler.generateIgModuleSource()` / `BallerinaProjectGenerator.generateIgModule()`). The scratch
+directory is deleted before a fresh generation but **not after** — it's currently left behind as a duplicate of
+what's in `modules/`, a known cleanup gap.
+
+### Verifying template-generation changes locally
+
+Since `fhir-to-bal-template` has no automated tests, checking a template/Velocity change means actually generating
+and compiling the output:
+
+```shell
+mvn clean install
+cd ballerina/target/health-tool-ballerina
+bal push --repository=local
+bal tool pull health:<version> --repository=local   # version comes from pom.xml, e.g. health:4.0.0
+
+cd /somewhere/scratch
+bal health fhir -m template --ig hl7.fhir.us.core -o ./out   # or whatever exercises the change
+cd out/fhir-service   # or ./out if --flat was used
+bal build             # the real check: Velocity syntax errors and the compiler-plugin rule above
+                       # only ever surface here
+```
+
+To revert to whichever `health` version was active before testing: `bal tool remove health:<version>
+--repository=local` (not `bal tool pull <old-version>` — pulling a version that's already cached locally does
+*not* reactivate it; removing the active version falls back to the next installed one automatically).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,20 +266,23 @@ This is coupled to the `packageMappings` auto-apply question directly below: wit
 mapping, a multi-IG generation would embed *every* IG as a separate local module by default, even for IGs with a
 known-correct published package already available.
 
-## `packageMappings` (`tool-config.json`'s `fhir.igRegistry.packageMappings`): still name-only in code
+## `packageMappings` (`tool-config.json`'s `fhir.igRegistry.packageMappings`)
 
-Despite being discussed at length and having confirmed, version-pinned mappings ready, **the code has not been
-updated yet** — don't assume adding entries to `tool-config.json` is sufficient on its own:
+`IgRegistryConfig.resolveDependentPackage(igName, igVersion)` is version-aware: it looks up
+`packageMappings.get(igName + "@" + igVersion)`, matching `--ig`'s own npm-style grammar, so a mapping only ever
+applies to the exact IG version it was confirmed for — it was originally keyed by bare IG name alone, which meant
+a mapping intended for one specific version silently matched *any* requested version of that IG (confirmed live:
+the `hl7.fhir.us.core` entry used to fire even when `--ig` resolved to latest/`9.0.0`, not just its intended
+`6.1.0`). Don't reintroduce a bare-name key — it would bring the same bug back.
 
-- `IgRegistryConfig.resolveDependentPackage(String igName)` still looks up by bare IG name only. Adding a
-  version-suffixed key like `"hl7.fhir.us.carin-bb.r4@2.1.0"` to the JSON will silently never match anything
-  until this is changed to `resolveDependentPackage(igName, igVersion)`, keyed by `igName + "@" + igVersion`
-  (matching `--ig`'s own npm-style grammar) — the fix is small and does not depend on the open question below.
-- Whether an exact match should **auto-apply** `--dependent-package` (like the international-base-detection path
-  already does silently) or remain **advisory-only** (today's behavior — an `[INFO]` suggestion, local embedding
-  still happens by default) is an open decision, not yet made.
-- Confirmed, version-pinned mappings collected so far, not yet added to `tool-config.json`:
-  `hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
-  `hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200`.
-  A package's own version-ish naming suffix does not reliably indicate the IG version it targets — confirm with
-  someone who knows, don't infer from the package name (`carinbb200` targets IG `2.1.0`, not `2.0.0`).
+**Still advisory-only, not auto-applying.** A match prints an `[INFO]` suggestion; the IG still gets embedded
+locally by default unless the user adds `--dependent-package` themselves. Whether an exact match should instead
+**auto-apply** `--dependent-package` (the way the international-base-detection path already does silently) is an
+open decision, not yet made.
+
+Confirmed, version-pinned mappings currently in `tool-config.json`:
+`hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
+`hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200`.
+A package's own version-ish naming suffix does not reliably indicate the IG version it targets — these were
+confirmed by someone who knows, not inferred from the name (`carinbb200` targets IG `2.1.0`, not `2.0.0`). Get
+confirmation before adding more; don't guess from the package name.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,14 +134,21 @@ ballerina                      — packages health-cli + all native jars into a 
 bal health fhir -m package --package-name my.package.name -o output-dir spec-path
 bal health fhir -m package --package-name my.package.name --ig hl7.fhir.us.core@8.0.1 -o output-dir
 bal health fhir -m template --ig hl7.fhir.us.core -o output-dir
+bal health fhir -m template --ig hl7.fhir.us.carin-bb.r4@2.1.0 --ig hl7.fhir.us.davinci-pdex-plan-net@1.2.0 -o output-dir
 bal health fhir -m template -o output-dir spec-path
 bal health fhir -m connector --config configuration-file-path -o output-dir
 ```
 
 A local `spec-path` and `--ig <name>[@version]` (a registry download — see below) are alternative ways to supply
-FHIR definitions to `package`/`template` mode. A local `spec-path` must contain one subfolder per Implementation
-Guide, each holding that IG's FHIR definition JSON files (`StructureDefinition-*.json`, `ValueSet-*.json`,
-`CodeSystem-*.json`, ...). Real fixtures for this layout live under `native/health-cli/src/test/resources/profiles.*`.
+FHIR definitions to `package`/`template` mode. A local `spec-path` holds one IG's FHIR definition JSON files
+directly (`StructureDefinition-*.json`, `ValueSet-*.json`, `CodeSystem-*.json`, ...) — real fixtures live under
+`native/health-cli/src/test/resources/profiles.*` (each one flat, a single IG's files with no subfolders). Despite
+what it might look like from `.fhir-ig-cache`'s naming, a spec directory containing several *different* IGs as
+sibling subfolders is **not** something the tool or the underlying framework auto-discovers/merges on its own —
+confirmed by testing (see "Multi-IG generation" below for what actually makes cross-IG merging work: repeatable
+`--ig`, not a multi-subfolder local path).
+`--ig` is repeatable in template mode for multi-IG generation (see below); every other mode/usage takes exactly
+one.
 
 Template mode defaults to a single **aggregated** service (`--aggregate false` for one service per FHIR resource
 instead), written under `<output>/fhir-service/` unless `--flat` is passed (writes directly into `<output>` instead
@@ -173,13 +180,14 @@ why (`FhirIgPackageDownloader.isVersionMismatch()` / `SpecificationPathUtils.rea
 `--force-ig-download` always re-fetches regardless of either check.
 
 `tool-config.json`'s `fhir.igRegistry.packageMappings` can suggest a known published Ballerina package for an
-exact `<ig-name>@<version>` match, but today this is **advisory only** — it prints an `[INFO]` suggestion and
-still embeds the IG locally by default; it does not auto-apply `--dependent-package` the way the
-international-base-detection path does (which *does* silently substitute a published package). Confirmed, correct
-version-pinned mappings collected so far: `hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
-`hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200` — note the package's own version-ish
-naming suffix does *not* reliably indicate the IG version it targets (`carinbb200` ↔ IG `2.1.0`, not `2.0.0`);
-don't infer a mapping from a package name alone.
+exact `<ig-name>@<version>` match. For a single `--ig` this is **advisory only** — it prints an `[INFO]` suggestion
+and still embeds the IG locally by default; it does not auto-apply `--dependent-package` the way the
+international-base-detection path does (which *does* silently substitute a published package). For 2+ `--ig`
+(multi-IG generation, below), a mapping is **required and auto-applied** for every IG — there's no other way to
+end up with a mixed set of dependent packages. See `tool-config.json` for the current confirmed, version-pinned
+mappings — note a package's own version-ish naming suffix does *not* reliably indicate the IG version it targets
+(e.g. `carinbb200` targets IG `2.1.0`, not `2.0.0`); don't infer a mapping from a package name alone, get it
+confirmed by someone who knows.
 
 ### Working in the Velocity templates (`fhir-to-bal-template/src/main/resources/template/*.vm`)
 
@@ -236,35 +244,93 @@ To revert to whichever `health` version was active before testing: `bal tool rem
 --repository=local` (not `bal tool pull <old-version>` — pulling a version that's already cached locally does
 *not* reactivate it; removing the active version falls back to the next installed one automatically).
 
-## Known limitation: no multi-IG generation
+## Multi-IG generation
 
-A real, validated requirement (confirmed against two independent hand-written services, `OrganizationService` and
-`PractitionerService`, in a real facade project) is generating a *single* resource type — e.g. `Organization` or
-`Practitioner` — whose profiles come from **two different IGs** (e.g. CARIN BB's `C4BBOrganization` and Da Vinci
-PDex Plan-Net's `PlannetOrganization`/`PlannetNetwork`), dispatched by `_profile` exactly like the multi-profile
-case above. **This is not possible today.** Three concrete reasons, not just "no flag for it yet":
+`--ig` is repeatable in template mode: `--ig hl7.fhir.us.carin-bb.r4@2.1.0 --ig hl7.fhir.us.davinci-pdex-plan-net@1.2.0`
+merges profiles from both IGs for the *same* resource type onto one service, dispatched by `_profile` — e.g.
+`Organization` ends up as `carinbb200:C4BBOrganization|davinciplannet120:PlannetOrganization`, each profile pulling
+from its own correctly-imported package. This is a direct generalization of the multi-profile-within-one-IG
+mechanism above (`addResourceProfile()`/`hasMultipleProfiles()`), not a new mechanism — verified end-to-end
+(`bal build` succeeds) against the real motivating case (CARIN BB + Da Vinci PDex Plan-Net `Organization`/
+`Practitioner`, matching a real hand-written facade project's `OrganizationService`/`PractitionerService`).
 
-1. `--ig` accepts exactly one value per invocation — there is no repeatable `--ig`.
-2. Running the tool twice against the same `-o` doesn't merge — `serviceMap` (where profiles accumulate per
-   resource type, see above) is rebuilt from scratch in-memory every invocation and never persisted, so a second
-   run would overwrite the first run's `Organization`/`Practitioner` output, not add to it.
-3. `IncludedIGConfig` is always keyed to the literal constant `"FHIR"` (see `FhirTemplateGenHandler`'s
-   `populateIGConfig()`/`HealthCmdConstants.CMD_DEFAULT_IG_NAME`), not the real IG name — the plumbing between the
-   CLI and the codegen engine is single-IG-shaped end to end, even though `BallerinaProjectToolConfig` itself has
-   an unused `populateIgConfigs(JsonArray)` path reading a static `"includedIGs"` array that was clearly built
-   with multiple IGs in mind.
+**Constraints:**
+- Multi-IG (2+ `--ig` values) only works in template mode.
+- Every IG in a multi-IG run must have a `packageMappings` entry (`tool-config.json`) — unlike single-IG, where a
+  mapping is advisory-only, multi-IG **auto-applies** it per IG (there is no other way to end up with a mixed set
+  of dependent packages). No mapping for one of the IGs → a clear error at resolve time, not a silent embed.
+  There's no "embed one unmapped IG locally while the others use published packages" support — an IG without a
+  mapping fails the whole run.
+- `--dependent-package` (a single global string) is rejected when 2+ `--ig` are given — it can't apply per IG.
+- Not validated: mixing FHIR versions (an r4 IG with an r5 IG) in one run. Nothing rejects this today.
 
-**The good part: the dispatch-skeleton generation is profile-driven, not IG-driven** — `addResourceProfile()`
-doesn't care which IG a profile came from, and the union-type-alias + per-profile `search<ProfileName>` stub +
-`match _profile` mechanism (see above) would produce the exact right shape for a merged multi-IG resource type
-*without any changes*, if only it were fed profiles from more than one IG in a single run. The missing piece is
-narrower than a redesign: make `--ig` repeatable, resolve each into its own `spec/<name>/` (existing machinery,
-no new download logic needed), and feed every resolved IG's StructureDefinitions through the same
-`addResourceProfile()` pass tagged with its real IG name instead of the `"FHIR"` constant.
+### The real root cause (found by reading the actual framework source, not guessed)
 
-This is coupled to the `packageMappings` auto-apply question directly below: without an auto-applying, accurate
-mapping, a multi-IG generation would embed *every* IG as a separate local module by default, even for IGs with a
-known-correct published package already available.
+The external `open-healthcare-codegen-tool-framework` never auto-discovers IG subfolders from a directory — a
+directory containing several IG subfolders side by side is **not** a thing the framework understands on its own.
+It only ever processes exactly the IGs explicitly given to it: `FHIRR4/R5SpecParser.parse()` iterates
+`FHIRToolConfig.getIgConfigs()` (a `Map<String, IGConfig>`, each entry an explicit `name` + `dirPath`) and calls
+`parseIG(toolConfig, igName, dirPath)` once per entry — the map key becomes the literal key under which
+`FHIRImplementationGuide` is stored in `getFhirImplementationGuides()`, independent of any file content.
+
+`health-cli`'s `Handler.initializeLib()` (the *only* thing that ever populated this for FHIR) never used that
+per-IG-config mechanism at all — it called `specParser.parseIG(fhirToolConfig, "FHIR", specificationPath)` directly,
+exactly once, hardcoded to the literal name `"FHIR"`, treating the *entire* given path as one IG's own directory.
+That's why single-IG always worked regardless of naming (nothing ever depended on the real IG name), and why
+pointing it at a directory with several real subfolders failed outright (`listFiles()` on the parent finds no
+`.json` files directly inside it, so the one "FHIR" IG's resources map stays empty → "No services found to
+generate", or "No resources found in the IG: FHIR" from the package-gen embed step) — **not** a directory-walking
+gap to fix, but a call site that needed to call `parseIG()` once per real IG instead of once with a placeholder
+name.
+
+### What changed to make it work
+
+- **`FhirSubCmd`**: `--ig` is `String[]` (repeatable); validated per element; rejects multi-IG outside template
+  mode and multi-IG combined with `--dependent-package`.
+- **`SpecificationPathResolver.resolve()`**: single `--ig` is untouched (own branch, same `spec/<name>/` leaf path
+  as before). 2+ `--ig` downloads each into its own `spec/<name>/` (same per-IG download machinery), validates
+  every one resolves via `packageMappings` (throws a clear `BallerinaHealthException` otherwise), and returns
+  their shared `spec/` parent as the specification path plus a `List<ResolvedIg>` (name, version, mapped package).
+- **`Handler`/`HandlerFactory`**: `Handler` gained a default `init(printStream, path, resolvedIgs)` overload
+  (falls back to the existing 2-arg `init` when not overridden — every handler except `FhirTemplateGenHandler`
+  behaves exactly as before). `HandlerFactory` gained a matching `createHandler(..., resolvedIgs)` overload; only
+  the `fhir:template` case passes `resolvedIgs` through.
+- **`FhirTemplateGenHandler`**: for 2+ resolved IGs, bypasses `Handler.initializeLib()`'s single hardcoded
+  `parseIG` call with `initializeMultiIgLib()`, which calls `specParser.parseIG(fhirToolConfig, resolvedIg.igName(),
+  <that IG's own spec/<name>/ dir>)` once per IG — giving the framework real per-IG identities instead of one
+  placeholder. It also builds one `IncludedIGConfig` per IG (keyed by that same real name, `importStatement` =
+  that IG's own `packageMappings`-resolved package) instead of the single `HealthCmdConstants.CMD_DEFAULT_IG_NAME`
+  ("FHIR") entry used for single-IG/local-spec-path — and skips the embed-module and international-base-default
+  logic entirely for multi-IG (neither applies once every IG already has a resolved package).
+- **`AbstractBallerinaProjectTool.populateIGs()`**: single-IG's existing behavior (rename the one IG's `igMap` key
+  and `IncludedIGConfig.importStatement` to the tool-wide `versionConfig.getNamePrefix()`-derived value) is
+  preserved byte-for-byte for exactly one `IncludedIGConfig` entry. For 2+ entries, that rename is skipped
+  entirely — each IG keeps its own real name as its `igMap` key and its own already-correct `importStatement`,
+  since collapsing them onto one shared key/value (as single-IG does) would make the second IG silently overwrite
+  the first.
+- **`FHIRProfile.setPackagePrefix()`**: looks up `config.getIncludedIGConfigs().get(this.getIgName())` first,
+  falling back to the old single global `config.getVersionConfig().getDependentPackage()` only if that profile's
+  own IG isn't found — so each profile's type-alias prefix comes from its own IG's resolved package rather than
+  always the tool-wide default. Backward-compatible for single-IG: after `populateIGs()`'s existing rename, both
+  maps land on the same key, so the lookup returns the same value the old code path computed.
+- **`ServiceGenerator`/`AggregatedServiceGenerator`**: additionally import every distinct profile-level import
+  (`profile.getImportsList()`), but **only when there are 2+ `IncludedIGConfig` entries**. This guard matters:
+  `profile.getImportsList()` is populated early (during `populateBalService()`, before embed-mode's real
+  local-module import or an explicit `--dependent-package`'s org get resolved), so for single-IG it holds a
+  stale/differently-orged value that would produce a broken or duplicate/conflicting import if surfaced — it was
+  harmless before only because nothing read it. Multi-IG's `importStatement` values are never rewritten this way
+  (previous point), so they're safe to surface unconditionally there.
+
+### Known issue found (and confirmed pre-existing, unrelated to multi-IG)
+
+Generating from a large spec in aggregated mode can hit `redeclared symbol 'search<ProfileName>'` at `bal build`
+time: the per-profile dispatch-skeleton stub functions (see "Working in the Velocity templates" above) are named
+by profile name alone, module-level, with no resource-type qualification. If two *different* resource types both
+carry a same-named profile (observed with the raw international-base R4 core spec's generic `ExampleLipidProfile`
+example profiles, reused verbatim across unrelated resources), their stub functions collide. Confirmed via
+`git stash` + rebuild that this reproduces identically on the commit before multi-IG generation was implemented —
+a pre-existing gap in the single-IG multi-profile dispatch work, not something multi-IG introduced. Not yet fixed;
+a real fix needs the stub function name qualified by resource type, not just profile name.
 
 ## `packageMappings` (`tool-config.json`'s `fhir.igRegistry.packageMappings`)
 
@@ -275,14 +341,15 @@ a mapping intended for one specific version silently matched *any* requested ver
 the `hl7.fhir.us.core` entry used to fire even when `--ig` resolved to latest/`9.0.0`, not just its intended
 `6.1.0`). Don't reintroduce a bare-name key — it would bring the same bug back.
 
-**Still advisory-only, not auto-applying.** A match prints an `[INFO]` suggestion; the IG still gets embedded
-locally by default unless the user adds `--dependent-package` themselves. Whether an exact match should instead
-**auto-apply** `--dependent-package` (the way the international-base-detection path already does silently) is an
-open decision, not yet made.
+**Still advisory-only, not auto-applying, for single-IG runs.** A match prints an `[INFO]` suggestion; the IG
+still gets embedded locally by default unless the user adds `--dependent-package` themselves. Whether an exact
+match should instead **auto-apply** `--dependent-package` for a single `--ig` (the way the international-base-
+detection path already does silently) is still an open decision, not yet made — but multi-IG generation (above)
+*does* decide this narrowly for its own case: resolution there is always auto-applied per IG (enforced — a
+multi-IG run fails outright if any IG has no mapping), since there's no other way to end up with a mixed set of
+dependent packages.
 
-Confirmed, version-pinned mappings currently in `tool-config.json`:
-`hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
-`hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200`.
-A package's own version-ish naming suffix does not reliably indicate the IG version it targets — these were
-confirmed by someone who knows, not inferred from the name (`carinbb200` targets IG `2.1.0`, not `2.0.0`). Get
-confirmation before adding more; don't guess from the package name.
+See `tool-config.json` for the currently confirmed, version-pinned mappings. A package's own version-ish naming
+suffix does not reliably indicate the IG version it targets — these were confirmed by someone who knows, not
+inferred from the name (e.g. `carinbb200` targets IG `2.1.0`, not `2.0.0`). Get confirmation before adding more;
+don't guess from the package name.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,237 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+`fhir-tools` builds the **Ballerina Health Tool** (`bal health`) — a `bal` CLI tool for generating Ballerina
+artifacts (packages, service templates, client connectors) from FHIR Implementation Guides (IGs) and CDS Hooks
+definitions. It is a multi-module Maven project (Java 21) whose final output is packaged as a Ballerina tool
+(`health-tool-ballerina`) and published to Ballerina Central. A separate Python MCP server exposes the same
+`bal health` commands as AI-callable tools.
+
+## Prerequisites & one-time setup
+
+- Java 17+ (repo compiles with `maven.compiler.source/target` = 21)
+- Ballerina Swan Lake **2201.12.3** (`bal` must be on `PATH`) — required to run the `bal pack`/`bal test` steps
+  invoked from Maven
+- A GitHub Personal Access Token with read access to GitHub Packages, added to `~/.m2/settings.xml` with server id
+  `ballerina-language-repo` (needed to resolve `ballerina-lang`/`ballerina-cli` artifacts):
+  ```xml
+  <servers>
+      <server>
+          <id>ballerina-language-repo</id>
+          <username>{Github_username}</username>
+          <password>{Github_PAT}</password>
+      </server>
+  </servers>
+  ```
+- The [`wso2/open-healthcare-codegen-tool-framework`](https://github.com/wso2/open-healthcare-codegen-tool-framework)
+  repo (currently pinned to `v2.1.2` via `version.healthcare.tool.framework` in the root `pom.xml`) must be built
+  and `mvn clean install`ed locally first — this repo's modules depend on its `commons`/`fhir-core` artifacts, which
+  are not on Maven Central.
+- If `mvn clean install` fails resolving `org.wso2.healthcare.codegen.tool.framework:*` even after installing the
+  framework above, check `~/.m2/repository/org/wso2/healthcare/codegen/tool/framework/*/*.lastUpdated` — Maven
+  caches a *negative* resolution result there if it ever tried (and failed) to fetch these artifacts remotely
+  before the local install existed. Delete that directory tree and rebuild; these artifacts only ever come from
+  the local install, never from `ballerina-language-repo` or Central.
+
+## Build & test
+
+```shell
+# from repo root, after the codegen-tool-framework has been installed locally
+mvn clean install
+```
+
+This builds every module in the order declared in the root `pom.xml` and finishes by running `bal pack` to produce
+the `health-tool-ballerina` Ballerina package under `ballerina/target/health-tool-ballerina`.
+
+- Build a single module (respecting the reactor for its dependencies): `mvn clean install -pl native/health-cli -am`
+- **Only `native/health-cli` has JUnit coverage** (JUnit 5, added alongside the `--ig` registry-download feature).
+  `fhir-to-bal-template`, `fhir-to-bal-connector`, and `cds-bal-template` have no `src/test` directory and no test
+  dependency at all — see "Verifying template-generation changes" below for how correctness of *those* modules is
+  actually checked.
+- Beyond JUnit, `native/health-cli`'s `packageGenTests` Maven profile (active by default) drives a second,
+  integration-style check via `exec-maven-plugin`:
+  1. `TestRunner.java` (`native/health-cli/src/test/java/TestRunner.java`) invokes the FHIR **package**-gen handler
+     directly (bypassing the CLI/picocli layer) against the bundled fixtures — `profiles.USCore` for FHIR **R4**
+     and `profiles.EuropeBase` for FHIR **R5** (system property `fhirVersion` selects which one runs), plus a CDS
+     template run against `cds.hooks/tool-config.toml`. This never exercises template-mode generation.
+  2. The generated Ballerina packages are then exercised with `bal test` against `.bal` test files copied in from
+     `native/fhir-to-bal-lib/src/test/resources/ballerina.tests/{r4,r5}`.
+  - To iterate on this locally: `mvn test -pl native/health-cli -am`. To change what's exercised, edit the fixtures
+    under `native/health-cli/src/test/resources/profiles.*` or the `.bal` files under
+    `native/fhir-to-bal-lib/src/test/resources/ballerina.tests/`.
+- CI (`.github/workflows/ci.yml`) does the same thing on every PR: checks out this repo plus
+  `open-healthcare-codegen-tool-framework` at the pinned tag, builds the framework, then runs `mvn clean install`
+  on this repo.
+- Release/publish (`.github/workflows/cd.yml`) is a manual `workflow_dispatch` (inputs: `bal_central_environment` =
+  `STAGE`/`DEV`/`PROD`) that runs the same build, then `bal push`es `ballerina/target/health-tool-ballerina` to that
+  Ballerina Central environment. On `PROD` it additionally cuts a GitHub Release tagged from the current `pom.xml`
+  version, bumps the patch version across **all** module `pom.xml` files, and opens a "prepare for next dev cycle"
+  PR back to `main`. This is the only supported publish path — there is no CLI command to unpublish or delete an
+  already-published version, only `bal deprecate <org>/<name>[:<version>]` (reversible with `--undo`; does not
+  delete anything, just discourages future dependency resolution onto it).
+
+### Keeping versions in sync
+
+The version is duplicated across `pom.xml` (root), `ballerina/pom.xml`, and every `native/*/pom.xml`. When bumping
+the version manually, update all of them (see the `sed` list in `cd.yml`'s "Update version in the pom files" step
+for the authoritative file list).
+
+## Architecture
+
+### Module graph (build order, from the root `pom.xml`)
+
+```
+native/fhir-to-bal-template   ─┐
+native/fhir-to-bal-lib         │  independent Java codegen libraries
+native/cds-bal-template        │  (each wraps a Tool from open-healthcare-codegen-tool-framework)
+native/fhir-to-bal-connector  ─┘
+native/health-cli              — CLI entry point; depends on the four modules above at runtime via reflection
+ballerina                      — packages health-cli + all native jars into a `bal tool` distributable
+```
+
+- **`native/fhir-to-bal-lib`** — generates a Ballerina **package** (data types, resources, extensions) from a FHIR
+  IG's `StructureDefinition`/`ValueSet`/`CodeSystem` JSON files. Version-specific logic lives under
+  `packagegen/tool/modelgen/versions/{r4,r5}`; Velocity templates live in `src/main/resources/templates`.
+- **`native/fhir-to-bal-template`** — generates a Ballerina **service template** (FHIR API scaffolding: resource
+  handlers, OpenAPI spec, `Component.yaml`) that depends on a previously generated package (or an IG module
+  embedded locally — see below). Also version-specific under `project/tool/versions/{r4,r5}`; templates in
+  `src/main/resources/template`. See "Working in the Velocity templates" below before editing these.
+- **`native/fhir-to-bal-connector`** — generates a Ballerina **client connector** for a remote FHIR server, driven
+  by that server's `CapabilityStatement` (see `model/CapabilityStatement.java`, `model/ConnectorOperation.java`).
+- **`native/cds-bal-template`** — generates a Ballerina **CDS Hooks** service template from a TOML hook-definitions
+  file (`BallerinaCDSProjectTool`, templates in `src/main/resources/template`). Its `cdsBalService.vm` copyright
+  header is written entirely as `##`-prefixed Velocity comments, so it's stripped at render time — CDS-generated
+  files currently ship with no copyright header at all (a latent bug, not a deliberate omission).
+- **`native/health-cli`** — the actual `bal health` command. `HealthCmd` (picocli root command) dispatches to
+  `FhirSubCmd` / `Hl7SubCmd` / `CdsSubCmd`. Each subcommand resolves a `Handler` via
+  `handler/HandlerFactory.createHandler(subCommand, mode, ...)`, keyed by `"<subcommand>:<mode>"` (e.g.
+  `fhir:package`, `fhir:template`, `fhir:connector`, `cds:template`). Handlers **reflectively load** the
+  corresponding `Tool`/`ToolConfig` classes from the codegen modules above (see the hardcoded class names in
+  `FhirPackageGenHandler`, e.g. `org.wso2....packagegen.tool.BallerinaPackageGenTool`) rather than depending on
+  them at compile time — keep those fully-qualified class name strings in sync if you rename/move classes in the
+  `native/fhir-to-bal-*` modules. Per-mode default configuration (base packages, dependent packages, repository
+  URLs per FHIR version, FHIR-registry defaults, etc.) lives in the JSON resources `tool-config.json` /
+  `cds-tool-config.json` / `connector-tool-config.json` under `native/health-cli/src/main/resources`, and is
+  overridden at runtime by CLI flags via `ToolConfig.overrideConfig(...)`.
+- **`ballerina`** — not a real Ballerina package at rest; `src/main/resources/health-tool-ballerina` is a template
+  that Maven's `maven-antrun-plugin`/`exec-maven-plugin` fill in at `package`/`install` time: it copies all the
+  native jars into `resources/`, generates `BalTool.toml` listing them as dependencies, and runs `bal pack`. This
+  is the artifact that gets `bal push`ed to Ballerina Central.
+- **`mcp/health-tool-mcp`** — standalone Python **FastMCP** server (`server.py`) that shells out to the installed
+  `bal health` CLI and exposes `fhirPackageGeneration`, `fhirTemplateGeneration`, and `cdsTemplateGeneration` as MCP
+  tools for AI clients (e.g. Claude Desktop). It is independent of the Maven build — see
+  `mcp/health-tool-mcp/README.md` for its own setup (`uv sync` / `pip install -r requirements.txt`,
+  `uv run fastmcp run server.py`). Configured via `MCP_WORKSPACE`, `MCP_LOG_DIR`, `MCP_SUBPROCESS_TIMEOUT`,
+  `MCP_MIN_FREE_DISK_MB`, `MCP_CLIENT_NAME` env vars; logs structured JSONL to `$MCP_LOG_DIR/mcp_io.jsonl`. Always
+  passes `--minimal` for template generation, so it's unaffected by `--flat` (see below) — it was already flat.
+
+### `bal health` command surface
+
+```shell
+bal health fhir -m package --package-name my.package.name -o output-dir spec-path
+bal health fhir -m package --package-name my.package.name --ig hl7.fhir.us.core@8.0.1 -o output-dir
+bal health fhir -m template --ig hl7.fhir.us.core -o output-dir
+bal health fhir -m template -o output-dir spec-path
+bal health fhir -m connector --config configuration-file-path -o output-dir
+```
+
+A local `spec-path` and `--ig <name>[@version]` (a registry download — see below) are alternative ways to supply
+FHIR definitions to `package`/`template` mode. A local `spec-path` must contain one subfolder per Implementation
+Guide, each holding that IG's FHIR definition JSON files (`StructureDefinition-*.json`, `ValueSet-*.json`,
+`CodeSystem-*.json`, ...). Real fixtures for this layout live under `native/health-cli/src/test/resources/profiles.*`.
+
+Template mode defaults to a single **aggregated** service (`--aggregate false` for one service per FHIR resource
+instead), written under `<output>/fhir-service/` unless `--flat` is passed (writes directly into `<output>` instead
+— keeps `Ballerina.toml`/`.gitignore`/OAS/`.choreo`, unlike `--minimal`, which also flattens but drops all of
+those). `--package-name` is mandatory in package mode; in aggregated template mode it's optional and names the
+generated project itself (default `FHIRServerTemplate`) — it has no effect with `--aggregate false`.
+
+### FHIR registry downloads (`--ig`)
+
+`--ig <name>[@version]` (npm-style, e.g. `hl7.fhir.us.core@8.0.1`; a bare name resolves to the latest published
+version, auto-selected non-interactively whenever there's no TTY) downloads an Implementation Guide from the FHIR
+package registry (default `https://packages.fhir.org`, override with `--registry-url`) instead of requiring a
+local `spec-path`. Implemented in `FhirIgPackageDownloader` (`native/health-cli/.../core/utils/`) and orchestrated
+by `SpecificationPathResolver.resolve()`.
+
+Two distinct, persistent locations are involved, not one:
+- **`.fhir-ig-cache/<name>-<version>.tgz`** (override with `--ig-cache-dir`) — the raw downloaded archive, cached
+  purely to avoid re-hitting the network on a future run. To pre-seed it yourself, the file must match this exact
+  naming convention; if `--ig-cache-dir` is explicitly set and misses, a `[WARN]` says so before falling back to
+  the network.
+- **`spec/<sanitized-name>/`** — the *extracted* JSON files the codegen framework actually reads (it needs real
+  files on disk, not a `.tgz`). This mirrors the tool's original, pre-registry-download convention of a
+  user-supplied local spec directory, so it's treated as real project content, not disposable cache — unlike
+  `.fhir-ig-cache/`, it is not gitignored automatically.
+
+`downloadAndExtract()` short-circuits (no network, no extraction) if `spec/<name>/` already has valid content —
+*unless* the on-disk `package.json` version doesn't match what was requested, in which case it re-fetches and logs
+why (`FhirIgPackageDownloader.isVersionMismatch()` / `SpecificationPathUtils.readInstalledPackageVersion()`).
+`--force-ig-download` always re-fetches regardless of either check.
+
+`tool-config.json`'s `fhir.igRegistry.packageMappings` can suggest a known published Ballerina package for an
+exact `<ig-name>@<version>` match, but today this is **advisory only** — it prints an `[INFO]` suggestion and
+still embeds the IG locally by default; it does not auto-apply `--dependent-package` the way the
+international-base-detection path does (which *does* silently substitute a published package). Confirmed, correct
+version-pinned mappings collected so far: `hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
+`hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200` — note the package's own version-ish
+naming suffix does *not* reliably indicate the IG version it targets (`carinbb200` ↔ IG `2.1.0`, not `2.0.0`);
+don't infer a mapping from a package name alone.
+
+### Working in the Velocity templates (`fhir-to-bal-template/src/main/resources/template/*.vm`)
+
+Two non-obvious constraints are easy to violate and only surface as errors at `bal build` time on the *generated*
+output, never at `mvn compile` time on the templates themselves:
+
+- **Anything declared inside a `service ... on new Listener(...) { ... }` block is a service member, not a free
+  function.** Calling it by bare name from another function *inside the same block* fails with "undefined
+  function" — Ballerina requires `self.` to reach a service's own members. Helper functions meant to be called
+  from a resource function (e.g. per-profile search stubs) must be declared *outside* the `service { ... }` block,
+  at module level, alongside the type aliases.
+- **`ballerinax/health.fhir.r4` ships its own compiler plugin with FHIR-specific resource-function rules**
+  (diagnostic code `FHIR_103`, distinct from ordinary Ballerina `BCE` errors) — it rejects search parameters
+  declared as ordinary resource-function parameters. Every generated resource function takes only
+  `FHIRContext fhirContext`; any additional search parameter (e.g. `_profile`) must be read from inside the
+  function body via `fhirContext.getRequestSearchParameter("<name>")` (returns
+  `readonly & RequestSearchParameter[]?`; each entry has a plain `.value` string field) — never as a second
+  declared parameter.
+
+`BallerinaService`/`FHIRProfile` (`fhir-to-bal-template/.../model/`) key generation by bare FHIR resource *type*,
+not by profile: when a resource type is profiled more than once — even within a single IG (e.g. US Core's ~26
+profiles of `Observation`) — every profile accumulates onto the *same* `BallerinaService`
+(`R4/R5BallerinaProjectTool.addResourceProfile()`), producing a union type alias. The generated search function
+dispatches across them by `_profile` (per the gotcha above); every other resource function (read-by-id,
+POST/PUT/PATCH/DELETE, history) stays a single generic stub regardless of profile count, since `_profile` is the
+one signal the tool can dispatch on before it has a typed value in hand.
+
+Embedding an IG as a local module (the default in template mode when `--dependent-package` isn't given) works by
+running the **package** generator into a scratch directory, `<output>/.generated-ig-package/`, then copying the
+resulting `.bal` sources into `<output>/modules/<ig-module-name>/`
+(`FhirTemplateGenHandler.generateIgModuleSource()` / `BallerinaProjectGenerator.generateIgModule()`). The scratch
+directory is deleted before a fresh generation but **not after** — it's currently left behind as a duplicate of
+what's in `modules/`, a known cleanup gap.
+
+### Verifying template-generation changes locally
+
+Since `fhir-to-bal-template` has no automated tests, checking a template/Velocity change means actually generating
+and compiling the output:
+
+```shell
+mvn clean install
+cd ballerina/target/health-tool-ballerina
+bal push --repository=local
+bal tool pull health:<version> --repository=local   # version comes from pom.xml, e.g. health:4.0.0
+
+cd /somewhere/scratch
+bal health fhir -m template --ig hl7.fhir.us.core -o ./out   # or whatever exercises the change
+cd out/fhir-service   # or ./out if --flat was used
+bal build             # the real check: Velocity syntax errors and the compiler-plugin rule above
+                       # only ever surface here
+```
+
+To revert to whichever `health` version was active before testing: `bal tool remove health:<version>
+--repository=local` (not `bal tool pull <old-version>` — pulling a version that's already cached locally does
+*not* reactivate it; removing the active version falls back to the next installed one automatically).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,3 +235,51 @@ bal build             # the real check: Velocity syntax errors and the compiler-
 To revert to whichever `health` version was active before testing: `bal tool remove health:<version>
 --repository=local` (not `bal tool pull <old-version>` — pulling a version that's already cached locally does
 *not* reactivate it; removing the active version falls back to the next installed one automatically).
+
+## Known limitation: no multi-IG generation
+
+A real, validated requirement (confirmed against two independent hand-written services, `OrganizationService` and
+`PractitionerService`, in a real facade project) is generating a *single* resource type — e.g. `Organization` or
+`Practitioner` — whose profiles come from **two different IGs** (e.g. CARIN BB's `C4BBOrganization` and Da Vinci
+PDex Plan-Net's `PlannetOrganization`/`PlannetNetwork`), dispatched by `_profile` exactly like the multi-profile
+case above. **This is not possible today.** Three concrete reasons, not just "no flag for it yet":
+
+1. `--ig` accepts exactly one value per invocation — there is no repeatable `--ig`.
+2. Running the tool twice against the same `-o` doesn't merge — `serviceMap` (where profiles accumulate per
+   resource type, see above) is rebuilt from scratch in-memory every invocation and never persisted, so a second
+   run would overwrite the first run's `Organization`/`Practitioner` output, not add to it.
+3. `IncludedIGConfig` is always keyed to the literal constant `"FHIR"` (see `FhirTemplateGenHandler`'s
+   `populateIGConfig()`/`HealthCmdConstants.CMD_DEFAULT_IG_NAME`), not the real IG name — the plumbing between the
+   CLI and the codegen engine is single-IG-shaped end to end, even though `BallerinaProjectToolConfig` itself has
+   an unused `populateIgConfigs(JsonArray)` path reading a static `"includedIGs"` array that was clearly built
+   with multiple IGs in mind.
+
+**The good part: the dispatch-skeleton generation is profile-driven, not IG-driven** — `addResourceProfile()`
+doesn't care which IG a profile came from, and the union-type-alias + per-profile `search<ProfileName>` stub +
+`match _profile` mechanism (see above) would produce the exact right shape for a merged multi-IG resource type
+*without any changes*, if only it were fed profiles from more than one IG in a single run. The missing piece is
+narrower than a redesign: make `--ig` repeatable, resolve each into its own `spec/<name>/` (existing machinery,
+no new download logic needed), and feed every resolved IG's StructureDefinitions through the same
+`addResourceProfile()` pass tagged with its real IG name instead of the `"FHIR"` constant.
+
+This is coupled to the `packageMappings` auto-apply question directly below: without an auto-applying, accurate
+mapping, a multi-IG generation would embed *every* IG as a separate local module by default, even for IGs with a
+known-correct published package already available.
+
+## `packageMappings` (`tool-config.json`'s `fhir.igRegistry.packageMappings`): still name-only in code
+
+Despite being discussed at length and having confirmed, version-pinned mappings ready, **the code has not been
+updated yet** — don't assume adding entries to `tool-config.json` is sufficient on its own:
+
+- `IgRegistryConfig.resolveDependentPackage(String igName)` still looks up by bare IG name only. Adding a
+  version-suffixed key like `"hl7.fhir.us.carin-bb.r4@2.1.0"` to the JSON will silently never match anything
+  until this is changed to `resolveDependentPackage(igName, igVersion)`, keyed by `igName + "@" + igVersion`
+  (matching `--ig`'s own npm-style grammar) — the fix is small and does not depend on the open question below.
+- Whether an exact match should **auto-apply** `--dependent-package` (like the international-base-detection path
+  already does silently) or remain **advisory-only** (today's behavior — an `[INFO]` suggestion, local embedding
+  still happens by default) is an open decision, not yet made.
+- Confirmed, version-pinned mappings collected so far, not yet added to `tool-config.json`:
+  `hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
+  `hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200`.
+  A package's own version-ish naming suffix does not reliably indicate the IG version it targets — confirm with
+  someone who knows, don't infer from the package name (`carinbb200` targets IG `2.1.0`, not `2.0.0`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,20 +266,23 @@ This is coupled to the `packageMappings` auto-apply question directly below: wit
 mapping, a multi-IG generation would embed *every* IG as a separate local module by default, even for IGs with a
 known-correct published package already available.
 
-## `packageMappings` (`tool-config.json`'s `fhir.igRegistry.packageMappings`): still name-only in code
+## `packageMappings` (`tool-config.json`'s `fhir.igRegistry.packageMappings`)
 
-Despite being discussed at length and having confirmed, version-pinned mappings ready, **the code has not been
-updated yet** — don't assume adding entries to `tool-config.json` is sufficient on its own:
+`IgRegistryConfig.resolveDependentPackage(igName, igVersion)` is version-aware: it looks up
+`packageMappings.get(igName + "@" + igVersion)`, matching `--ig`'s own npm-style grammar, so a mapping only ever
+applies to the exact IG version it was confirmed for — it was originally keyed by bare IG name alone, which meant
+a mapping intended for one specific version silently matched *any* requested version of that IG (confirmed live:
+the `hl7.fhir.us.core` entry used to fire even when `--ig` resolved to latest/`9.0.0`, not just its intended
+`6.1.0`). Don't reintroduce a bare-name key — it would bring the same bug back.
 
-- `IgRegistryConfig.resolveDependentPackage(String igName)` still looks up by bare IG name only. Adding a
-  version-suffixed key like `"hl7.fhir.us.carin-bb.r4@2.1.0"` to the JSON will silently never match anything
-  until this is changed to `resolveDependentPackage(igName, igVersion)`, keyed by `igName + "@" + igVersion`
-  (matching `--ig`'s own npm-style grammar) — the fix is small and does not depend on the open question below.
-- Whether an exact match should **auto-apply** `--dependent-package` (like the international-base-detection path
-  already does silently) or remain **advisory-only** (today's behavior — an `[INFO]` suggestion, local embedding
-  still happens by default) is an open decision, not yet made.
-- Confirmed, version-pinned mappings collected so far, not yet added to `tool-config.json`:
-  `hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
-  `hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200`.
-  A package's own version-ish naming suffix does not reliably indicate the IG version it targets — confirm with
-  someone who knows, don't infer from the package name (`carinbb200` targets IG `2.1.0`, not `2.0.0`).
+**Still advisory-only, not auto-applying.** A match prints an `[INFO]` suggestion; the IG still gets embedded
+locally by default unless the user adds `--dependent-package` themselves. Whether an exact match should instead
+**auto-apply** `--dependent-package` (the way the international-base-detection path already does silently) is an
+open decision, not yet made.
+
+Confirmed, version-pinned mappings currently in `tool-config.json`:
+`hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
+`hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200`.
+A package's own version-ish naming suffix does not reliably indicate the IG version it targets — these were
+confirmed by someone who knows, not inferred from the name (`carinbb200` targets IG `2.1.0`, not `2.0.0`). Get
+confirmation before adding more; don't guess from the package name.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,14 +134,21 @@ ballerina                      — packages health-cli + all native jars into a 
 bal health fhir -m package --package-name my.package.name -o output-dir spec-path
 bal health fhir -m package --package-name my.package.name --ig hl7.fhir.us.core@8.0.1 -o output-dir
 bal health fhir -m template --ig hl7.fhir.us.core -o output-dir
+bal health fhir -m template --ig hl7.fhir.us.carin-bb.r4@2.1.0 --ig hl7.fhir.us.davinci-pdex-plan-net@1.2.0 -o output-dir
 bal health fhir -m template -o output-dir spec-path
 bal health fhir -m connector --config configuration-file-path -o output-dir
 ```
 
 A local `spec-path` and `--ig <name>[@version]` (a registry download — see below) are alternative ways to supply
-FHIR definitions to `package`/`template` mode. A local `spec-path` must contain one subfolder per Implementation
-Guide, each holding that IG's FHIR definition JSON files (`StructureDefinition-*.json`, `ValueSet-*.json`,
-`CodeSystem-*.json`, ...). Real fixtures for this layout live under `native/health-cli/src/test/resources/profiles.*`.
+FHIR definitions to `package`/`template` mode. A local `spec-path` holds one IG's FHIR definition JSON files
+directly (`StructureDefinition-*.json`, `ValueSet-*.json`, `CodeSystem-*.json`, ...) — real fixtures live under
+`native/health-cli/src/test/resources/profiles.*` (each one flat, a single IG's files with no subfolders). Despite
+what it might look like from `.fhir-ig-cache`'s naming, a spec directory containing several *different* IGs as
+sibling subfolders is **not** something the tool or the underlying framework auto-discovers/merges on its own —
+confirmed by testing (see "Multi-IG generation" below for what actually makes cross-IG merging work: repeatable
+`--ig`, not a multi-subfolder local path).
+`--ig` is repeatable in template mode for multi-IG generation (see below); every other mode/usage takes exactly
+one.
 
 Template mode defaults to a single **aggregated** service (`--aggregate false` for one service per FHIR resource
 instead), written under `<output>/fhir-service/` unless `--flat` is passed (writes directly into `<output>` instead
@@ -173,13 +180,14 @@ why (`FhirIgPackageDownloader.isVersionMismatch()` / `SpecificationPathUtils.rea
 `--force-ig-download` always re-fetches regardless of either check.
 
 `tool-config.json`'s `fhir.igRegistry.packageMappings` can suggest a known published Ballerina package for an
-exact `<ig-name>@<version>` match, but today this is **advisory only** — it prints an `[INFO]` suggestion and
-still embeds the IG locally by default; it does not auto-apply `--dependent-package` the way the
-international-base-detection path does (which *does* silently substitute a published package). Confirmed, correct
-version-pinned mappings collected so far: `hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
-`hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200` — note the package's own version-ish
-naming suffix does *not* reliably indicate the IG version it targets (`carinbb200` ↔ IG `2.1.0`, not `2.0.0`);
-don't infer a mapping from a package name alone.
+exact `<ig-name>@<version>` match. For a single `--ig` this is **advisory only** — it prints an `[INFO]` suggestion
+and still embeds the IG locally by default; it does not auto-apply `--dependent-package` the way the
+international-base-detection path does (which *does* silently substitute a published package). For 2+ `--ig`
+(multi-IG generation, below), a mapping is **required and auto-applied** for every IG — there's no other way to
+end up with a mixed set of dependent packages. See `tool-config.json` for the current confirmed, version-pinned
+mappings — note a package's own version-ish naming suffix does *not* reliably indicate the IG version it targets
+(e.g. `carinbb200` targets IG `2.1.0`, not `2.0.0`); don't infer a mapping from a package name alone, get it
+confirmed by someone who knows.
 
 ### Working in the Velocity templates (`fhir-to-bal-template/src/main/resources/template/*.vm`)
 
@@ -236,35 +244,93 @@ To revert to whichever `health` version was active before testing: `bal tool rem
 --repository=local` (not `bal tool pull <old-version>` — pulling a version that's already cached locally does
 *not* reactivate it; removing the active version falls back to the next installed one automatically).
 
-## Known limitation: no multi-IG generation
+## Multi-IG generation
 
-A real, validated requirement (confirmed against two independent hand-written services, `OrganizationService` and
-`PractitionerService`, in a real facade project) is generating a *single* resource type — e.g. `Organization` or
-`Practitioner` — whose profiles come from **two different IGs** (e.g. CARIN BB's `C4BBOrganization` and Da Vinci
-PDex Plan-Net's `PlannetOrganization`/`PlannetNetwork`), dispatched by `_profile` exactly like the multi-profile
-case above. **This is not possible today.** Three concrete reasons, not just "no flag for it yet":
+`--ig` is repeatable in template mode: `--ig hl7.fhir.us.carin-bb.r4@2.1.0 --ig hl7.fhir.us.davinci-pdex-plan-net@1.2.0`
+merges profiles from both IGs for the *same* resource type onto one service, dispatched by `_profile` — e.g.
+`Organization` ends up as `carinbb200:C4BBOrganization|davinciplannet120:PlannetOrganization`, each profile pulling
+from its own correctly-imported package. This is a direct generalization of the multi-profile-within-one-IG
+mechanism above (`addResourceProfile()`/`hasMultipleProfiles()`), not a new mechanism — verified end-to-end
+(`bal build` succeeds) against the real motivating case (CARIN BB + Da Vinci PDex Plan-Net `Organization`/
+`Practitioner`, matching a real hand-written facade project's `OrganizationService`/`PractitionerService`).
 
-1. `--ig` accepts exactly one value per invocation — there is no repeatable `--ig`.
-2. Running the tool twice against the same `-o` doesn't merge — `serviceMap` (where profiles accumulate per
-   resource type, see above) is rebuilt from scratch in-memory every invocation and never persisted, so a second
-   run would overwrite the first run's `Organization`/`Practitioner` output, not add to it.
-3. `IncludedIGConfig` is always keyed to the literal constant `"FHIR"` (see `FhirTemplateGenHandler`'s
-   `populateIGConfig()`/`HealthCmdConstants.CMD_DEFAULT_IG_NAME`), not the real IG name — the plumbing between the
-   CLI and the codegen engine is single-IG-shaped end to end, even though `BallerinaProjectToolConfig` itself has
-   an unused `populateIgConfigs(JsonArray)` path reading a static `"includedIGs"` array that was clearly built
-   with multiple IGs in mind.
+**Constraints:**
+- Multi-IG (2+ `--ig` values) only works in template mode.
+- Every IG in a multi-IG run must have a `packageMappings` entry (`tool-config.json`) — unlike single-IG, where a
+  mapping is advisory-only, multi-IG **auto-applies** it per IG (there is no other way to end up with a mixed set
+  of dependent packages). No mapping for one of the IGs → a clear error at resolve time, not a silent embed.
+  There's no "embed one unmapped IG locally while the others use published packages" support — an IG without a
+  mapping fails the whole run.
+- `--dependent-package` (a single global string) is rejected when 2+ `--ig` are given — it can't apply per IG.
+- Not validated: mixing FHIR versions (an r4 IG with an r5 IG) in one run. Nothing rejects this today.
 
-**The good part: the dispatch-skeleton generation is profile-driven, not IG-driven** — `addResourceProfile()`
-doesn't care which IG a profile came from, and the union-type-alias + per-profile `search<ProfileName>` stub +
-`match _profile` mechanism (see above) would produce the exact right shape for a merged multi-IG resource type
-*without any changes*, if only it were fed profiles from more than one IG in a single run. The missing piece is
-narrower than a redesign: make `--ig` repeatable, resolve each into its own `spec/<name>/` (existing machinery,
-no new download logic needed), and feed every resolved IG's StructureDefinitions through the same
-`addResourceProfile()` pass tagged with its real IG name instead of the `"FHIR"` constant.
+### The real root cause (found by reading the actual framework source, not guessed)
 
-This is coupled to the `packageMappings` auto-apply question directly below: without an auto-applying, accurate
-mapping, a multi-IG generation would embed *every* IG as a separate local module by default, even for IGs with a
-known-correct published package already available.
+The external `open-healthcare-codegen-tool-framework` never auto-discovers IG subfolders from a directory — a
+directory containing several IG subfolders side by side is **not** a thing the framework understands on its own.
+It only ever processes exactly the IGs explicitly given to it: `FHIRR4/R5SpecParser.parse()` iterates
+`FHIRToolConfig.getIgConfigs()` (a `Map<String, IGConfig>`, each entry an explicit `name` + `dirPath`) and calls
+`parseIG(toolConfig, igName, dirPath)` once per entry — the map key becomes the literal key under which
+`FHIRImplementationGuide` is stored in `getFhirImplementationGuides()`, independent of any file content.
+
+`health-cli`'s `Handler.initializeLib()` (the *only* thing that ever populated this for FHIR) never used that
+per-IG-config mechanism at all — it called `specParser.parseIG(fhirToolConfig, "FHIR", specificationPath)` directly,
+exactly once, hardcoded to the literal name `"FHIR"`, treating the *entire* given path as one IG's own directory.
+That's why single-IG always worked regardless of naming (nothing ever depended on the real IG name), and why
+pointing it at a directory with several real subfolders failed outright (`listFiles()` on the parent finds no
+`.json` files directly inside it, so the one "FHIR" IG's resources map stays empty → "No services found to
+generate", or "No resources found in the IG: FHIR" from the package-gen embed step) — **not** a directory-walking
+gap to fix, but a call site that needed to call `parseIG()` once per real IG instead of once with a placeholder
+name.
+
+### What changed to make it work
+
+- **`FhirSubCmd`**: `--ig` is `String[]` (repeatable); validated per element; rejects multi-IG outside template
+  mode and multi-IG combined with `--dependent-package`.
+- **`SpecificationPathResolver.resolve()`**: single `--ig` is untouched (own branch, same `spec/<name>/` leaf path
+  as before). 2+ `--ig` downloads each into its own `spec/<name>/` (same per-IG download machinery), validates
+  every one resolves via `packageMappings` (throws a clear `BallerinaHealthException` otherwise), and returns
+  their shared `spec/` parent as the specification path plus a `List<ResolvedIg>` (name, version, mapped package).
+- **`Handler`/`HandlerFactory`**: `Handler` gained a default `init(printStream, path, resolvedIgs)` overload
+  (falls back to the existing 2-arg `init` when not overridden — every handler except `FhirTemplateGenHandler`
+  behaves exactly as before). `HandlerFactory` gained a matching `createHandler(..., resolvedIgs)` overload; only
+  the `fhir:template` case passes `resolvedIgs` through.
+- **`FhirTemplateGenHandler`**: for 2+ resolved IGs, bypasses `Handler.initializeLib()`'s single hardcoded
+  `parseIG` call with `initializeMultiIgLib()`, which calls `specParser.parseIG(fhirToolConfig, resolvedIg.igName(),
+  <that IG's own spec/<name>/ dir>)` once per IG — giving the framework real per-IG identities instead of one
+  placeholder. It also builds one `IncludedIGConfig` per IG (keyed by that same real name, `importStatement` =
+  that IG's own `packageMappings`-resolved package) instead of the single `HealthCmdConstants.CMD_DEFAULT_IG_NAME`
+  ("FHIR") entry used for single-IG/local-spec-path — and skips the embed-module and international-base-default
+  logic entirely for multi-IG (neither applies once every IG already has a resolved package).
+- **`AbstractBallerinaProjectTool.populateIGs()`**: single-IG's existing behavior (rename the one IG's `igMap` key
+  and `IncludedIGConfig.importStatement` to the tool-wide `versionConfig.getNamePrefix()`-derived value) is
+  preserved byte-for-byte for exactly one `IncludedIGConfig` entry. For 2+ entries, that rename is skipped
+  entirely — each IG keeps its own real name as its `igMap` key and its own already-correct `importStatement`,
+  since collapsing them onto one shared key/value (as single-IG does) would make the second IG silently overwrite
+  the first.
+- **`FHIRProfile.setPackagePrefix()`**: looks up `config.getIncludedIGConfigs().get(this.getIgName())` first,
+  falling back to the old single global `config.getVersionConfig().getDependentPackage()` only if that profile's
+  own IG isn't found — so each profile's type-alias prefix comes from its own IG's resolved package rather than
+  always the tool-wide default. Backward-compatible for single-IG: after `populateIGs()`'s existing rename, both
+  maps land on the same key, so the lookup returns the same value the old code path computed.
+- **`ServiceGenerator`/`AggregatedServiceGenerator`**: additionally import every distinct profile-level import
+  (`profile.getImportsList()`), but **only when there are 2+ `IncludedIGConfig` entries**. This guard matters:
+  `profile.getImportsList()` is populated early (during `populateBalService()`, before embed-mode's real
+  local-module import or an explicit `--dependent-package`'s org get resolved), so for single-IG it holds a
+  stale/differently-orged value that would produce a broken or duplicate/conflicting import if surfaced — it was
+  harmless before only because nothing read it. Multi-IG's `importStatement` values are never rewritten this way
+  (previous point), so they're safe to surface unconditionally there.
+
+### Known issue found (and confirmed pre-existing, unrelated to multi-IG)
+
+Generating from a large spec in aggregated mode can hit `redeclared symbol 'search<ProfileName>'` at `bal build`
+time: the per-profile dispatch-skeleton stub functions (see "Working in the Velocity templates" above) are named
+by profile name alone, module-level, with no resource-type qualification. If two *different* resource types both
+carry a same-named profile (observed with the raw international-base R4 core spec's generic `ExampleLipidProfile`
+example profiles, reused verbatim across unrelated resources), their stub functions collide. Confirmed via
+`git stash` + rebuild that this reproduces identically on the commit before multi-IG generation was implemented —
+a pre-existing gap in the single-IG multi-profile dispatch work, not something multi-IG introduced. Not yet fixed;
+a real fix needs the stub function name qualified by resource type, not just profile name.
 
 ## `packageMappings` (`tool-config.json`'s `fhir.igRegistry.packageMappings`)
 
@@ -275,14 +341,15 @@ a mapping intended for one specific version silently matched *any* requested ver
 the `hl7.fhir.us.core` entry used to fire even when `--ig` resolved to latest/`9.0.0`, not just its intended
 `6.1.0`). Don't reintroduce a bare-name key — it would bring the same bug back.
 
-**Still advisory-only, not auto-applying.** A match prints an `[INFO]` suggestion; the IG still gets embedded
-locally by default unless the user adds `--dependent-package` themselves. Whether an exact match should instead
-**auto-apply** `--dependent-package` (the way the international-base-detection path already does silently) is an
-open decision, not yet made.
+**Still advisory-only, not auto-applying, for single-IG runs.** A match prints an `[INFO]` suggestion; the IG
+still gets embedded locally by default unless the user adds `--dependent-package` themselves. Whether an exact
+match should instead **auto-apply** `--dependent-package` for a single `--ig` (the way the international-base-
+detection path already does silently) is still an open decision, not yet made — but multi-IG generation (above)
+*does* decide this narrowly for its own case: resolution there is always auto-applied per IG (enforced — a
+multi-IG run fails outright if any IG has no mapping), since there's no other way to end up with a mixed set of
+dependent packages.
 
-Confirmed, version-pinned mappings currently in `tool-config.json`:
-`hl7.fhir.us.core@6.1.0` → `ballerinax/health.fhir.r4.uscore501`,
-`hl7.fhir.us.carin-bb.r4@2.1.0` → `ballerinax/health.fhir.r4.carinbb200`.
-A package's own version-ish naming suffix does not reliably indicate the IG version it targets — these were
-confirmed by someone who knows, not inferred from the name (`carinbb200` targets IG `2.1.0`, not `2.0.0`). Get
-confirmation before adding more; don't guess from the package name.
+See `tool-config.json` for the currently confirmed, version-pinned mappings. A package's own version-ish naming
+suffix does not reliably indicate the IG version it targets — these were confirmed by someone who knows, not
+inferred from the name (e.g. `carinbb200` targets IG `2.1.0`, not `2.0.0`). Get confirmation before adding more;
+don't guess from the package name.

--- a/README.md
+++ b/README.md
@@ -23,15 +23,19 @@
 ```
 
 ## Supported Commands
-```shell\
+```shell
 bal health fhir -m package -o output-dir spec-path
 bal health fhir -m package --package-name my.package.name -o output-dir spec-path
 bal health fhir -m template -o output-dir spec-path
+bal health fhir -m template -o output-dir
+bal health fhir -m template --ig-name hl7.fhir.us.core --ig-version 6.1.0 -o output-dir
+bal health fhir -m package --package-name my.package --ig-name hl7.fhir.us.core --ig-version 6.1.0 -o output-dir
 bal health fhir -m connector --config configuration-file-path -o output-dir
 ```
 ### Note
-- `spec-path` is the path to the FHIR specifications. (i.e. In the specified path, there should be folder/s for each 
-Implementation Guide containing the FHIR specification files.)
+- `spec-path` is optional when `--ig-name` is provided or when template mode should use the default HL7 R4 core IG (`hl7.fhir.r4.core` from [packages.fhir.org](https://packages.fhir.org), extracted under `spec/international`).
+- When `--ig-name` is set and `--ig-version` is omitted, the CLI lists published versions interactively (TTY); use `--non-interactive` in CI to pick `dist-tags.latest` automatically.
+- With a local layout, `spec-path` points to FHIR specification folders (Implementation Guide JSON files).
 
 Directory structure of the `spec-path` should be as follows.
 ```shell

--- a/ballerina/pom.xml
+++ b/ballerina/pom.xml
@@ -25,11 +25,11 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>health-tool-ballerina</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <properties>
         <version.health.cli>${project.version}</version.health.cli>

--- a/mcp/health-tool-mcp/server.py
+++ b/mcp/health-tool-mcp/server.py
@@ -460,18 +460,18 @@ _check_bal_at_startup()
 
 def _append_registry_ig_args(cmd: list, ig_name: Optional[str], ig_version: Optional[str]) -> None:
     if ig_name and ig_name.strip():
-        cmd.extend(["--ig-name", ig_name.strip()])
-    if ig_version and ig_version.strip():
-        cmd.extend(["--ig-version", ig_version.strip()])
+        name = ig_name.strip()
+        version = ig_version.strip() if ig_version and ig_version.strip() else None
+        cmd.extend(["--ig", f"{name}@{version}" if version else name])
 
 
 @mcp.tool(
-    description="Generate a Ballerina package from FHIR IG definitions. Provide a local definitions path under spec/<ig_name>, or use --ig-name/--ig-version to download from packages.fhir.org (e.g. hl7.fhir.us.core@6.1.0). Command: bal health fhir -m package --package-name <name> [--ig-name <id> --ig-version <ver>] -o <output> [<definitions_path>]"
+    description="Generate a Ballerina package from FHIR IG definitions. Provide a local definitions path under spec/<ig_name>, or use ig_name/ig_version to download from packages.fhir.org (e.g. hl7.fhir.us.core@6.1.0). Command: bal health fhir -m package --package-name <name> [--ig <id>[@<version>]] -o <output> [<definitions_path>]"
 )
 def fhirPackageGeneration(
-    fhir_spec_directory: Annotated[Optional[str], "Optional: Absolute path to FHIR IG definitions under spec/<ig_name>. Omit when using --ig-name to download from the registry."] = None,
+    fhir_spec_directory: Annotated[Optional[str], "Optional: Absolute path to FHIR IG definitions under spec/<ig_name>. Omit when using ig_name to download from the registry."] = None,
     ig_name: Annotated[Optional[str], "Optional: FHIR registry package id (e.g. hl7.fhir.us.core). Downloads from packages.fhir.org when no local path is given."] = None,
-    ig_version: Annotated[Optional[str], "Optional: FHIR registry package version (e.g. 6.1.0). If omitted, bal health prompts interactively in a TTY; use --non-interactive in scripts for latest."] = None,
+    ig_version: Annotated[Optional[str], "Optional: FHIR registry package version (e.g. 6.1.0). If omitted, bal health prompts interactively in a TTY, or automatically selects the latest version when run non-interactively (e.g. from this MCP server)."] = None,
     package_name: Annotated[Optional[str], "Optional: Name for the generated Ballerina package. If omitted, inferred from IG name."] = None,
     working_directory: Annotated[Optional[str], "Optional: Project directory. Auto-detected from path if not provided."] = None,
     org_name: Annotated[Optional[str], "Optional: Organization name"] = None,
@@ -778,13 +778,13 @@ def fhirPackageGeneration(
         )
 
 @mcp.tool(
-    description="Generate FHIR API templates from a FHIR Implementation Guide. Use a local definitions path, --ig-name/--ig-version to download from packages.fhir.org, or omit both to use default hl7.fhir.r4.core. Command: bal health fhir -m template [--dependent-package <pkg>] [--ig-name <id> --ig-version <ver>] -o <output> [<definitions_path>]"
+    description="Generate FHIR API templates from a FHIR Implementation Guide. Use a local definitions path, ig_name/ig_version to download from packages.fhir.org, or omit both to use default hl7.fhir.r4.core. Command: bal health fhir -m template [--dependent-package <pkg>] [--ig <id>[@<version>]] -o <output> [<definitions_path>]"
 )
 def fhirTemplateGeneration(
     dependent_package: Annotated[Optional[str], "Optional: Ballerina package (e.g. ballerinax/health.fhir.r4.uscore501). Inferred for known IGs or default R4 core."] = None,
     fhir_spec_directory: Annotated[Optional[str], "Optional: Absolute path to FHIR IG definitions. Omit to download via ig_name or default hl7.fhir.r4.core."] = None,
     ig_name: Annotated[Optional[str], "Optional: FHIR registry package id (e.g. hl7.fhir.us.core)."] = None,
-    ig_version: Annotated[Optional[str], "Optional: FHIR registry package version (e.g. 6.1.0). If omitted, bal health prompts interactively in a TTY; use --non-interactive in scripts for latest."] = None,
+    ig_version: Annotated[Optional[str], "Optional: FHIR registry package version (e.g. 6.1.0). If omitted, bal health prompts interactively in a TTY, or automatically selects the latest version when run non-interactively (e.g. from this MCP server)."] = None,
     working_directory: Annotated[Optional[str], "Optional: Project directory. Auto-detected from path if not provided."] = None,
     org_name: Annotated[Optional[str], "Optional: Organization name for generated templates"] = None,
     included_profiles: Annotated[Optional[list[str]], "Optional: FHIR profile URLs to ONLY include. Reduces generation time by skipping unwanted profiles."] = None,

--- a/mcp/health-tool-mcp/server.py
+++ b/mcp/health-tool-mcp/server.py
@@ -458,12 +458,20 @@ def _check_bal_at_startup() -> None:
 _check_bal_at_startup()
 
 
+def _append_registry_ig_args(cmd: list, ig_name: Optional[str], ig_version: Optional[str]) -> None:
+    if ig_name and ig_name.strip():
+        cmd.extend(["--ig-name", ig_name.strip()])
+    if ig_version and ig_version.strip():
+        cmd.extend(["--ig-version", ig_version.strip()])
+
+
 @mcp.tool(
-    description="Generate a Ballerina package from FHIR IG definitions. Required: absolute path to definitions under spec/<ig_name>. If missing, install via npm and move to spec:<newline>npm --registry https://packages.simplifier.net install <ig_name><newline>Examples: US Core hl7.fhir.us.core@8.0.1, CARIN BB hl7.fhir.us.carin-bb@2.1.0, PDex hl7.fhir.us.davinci-pdex@2.1.0. Command: bal health fhir -m package --package-name <name> -o <output> <definitions_path>"
+    description="Generate a Ballerina package from FHIR IG definitions. Provide a local definitions path under spec/<ig_name>, or use --ig-name/--ig-version to download from packages.fhir.org (e.g. hl7.fhir.us.core@6.1.0). Command: bal health fhir -m package --package-name <name> [--ig-name <id> --ig-version <ver>] -o <output> [<definitions_path>]"
 )
 def fhirPackageGeneration(
-    fhir_spec_directory: Annotated[Optional[str], "Required: Absolute path to FHIR IG definitions under spec/<ig_name>."] = None,
-    ig_name: Annotated[Optional[str], "Optional: IG name (e.g., 'hl7.fhir.us.core'). Used only for package name inference."] = None,
+    fhir_spec_directory: Annotated[Optional[str], "Optional: Absolute path to FHIR IG definitions under spec/<ig_name>. Omit when using --ig-name to download from the registry."] = None,
+    ig_name: Annotated[Optional[str], "Optional: FHIR registry package id (e.g. hl7.fhir.us.core). Downloads from packages.fhir.org when no local path is given."] = None,
+    ig_version: Annotated[Optional[str], "Optional: FHIR registry package version (e.g. 6.1.0). If omitted, bal health prompts interactively in a TTY; use --non-interactive in scripts for latest."] = None,
     package_name: Annotated[Optional[str], "Optional: Name for the generated Ballerina package. If omitted, inferred from IG name."] = None,
     working_directory: Annotated[Optional[str], "Optional: Project directory. Auto-detected from path if not provided."] = None,
     org_name: Annotated[Optional[str], "Optional: Organization name"] = None,
@@ -471,17 +479,14 @@ def fhirPackageGeneration(
     """Generate a Ballerina package from a FHIR Implementation Guide.
 
         Usage:
-        - Provide absolute definitions path under your project spec folder (e.g., "/home/user/project/spec/hl7.fhir.us.core").
-        - If definitions are not available, install via npm and move to spec:
-            npm --registry https://packages.simplifier.net install <ig_name>
-            Examples:
-                - US Core: hl7.fhir.us.core@8.0.1
-                - CARIN BB: hl7.fhir.us.carin-bb@2.1.0
-                - PDex: hl7.fhir.us.davinci-pdex@2.1.0
+        - Provide a local definitions path under spec/, or set ig_name (and optionally ig_version)
+          to download from https://packages.fhir.org into spec/ automatically.
+        - Alternative: npm --registry https://packages.simplifier.net install <ig_name>
 
     Args:
-        fhir_spec_directory: Required. Absolute path to FHIR IG definitions.
-        ig_name: Optional. IG name (e.g., "hl7.fhir.us.core", "hl7.fhir.us.carin-bb").
+        fhir_spec_directory: Optional. Absolute path to FHIR IG definitions.
+        ig_name: Optional. Registry package id (e.g. hl7.fhir.us.core).
+        ig_version: Optional. Registry package version (e.g. 6.1.0).
         package_name: Optional. Inferred from IG if omitted.
         working_directory: Optional. Auto-detected from path; if definitions path is <project>/spec/<ig-name>, uses <project>.
         org_name: Optional.
@@ -494,41 +499,39 @@ def fhirPackageGeneration(
     _caller = get_caller_identity()
     _start_time = time.time()
 
-    # Resolve inputs: require absolute definitions path under spec/<ig_name>
     setup_hint = (
-        "Place IG definitions under spec/<ig_name> and provide the absolute path.\n"
-        "If not available, install via npm and move to spec:\n"
-        "npm --registry https://packages.simplifier.net install <ig_name>\n"
-        "Examples: US Core hl7.fhir.us.core@8.0.1, CARIN BB hl7.fhir.us.carin-bb@2.1.0, PDex hl7.fhir.us.davinci-pdex@2.1.0"
-        "\nAfter moving files, provide the absolute path to the definitions again to generate the package."
-        "\nProvide user with the above instructions only keeping the message short and clear."
+        "Provide fhir_spec_directory, or set ig_name (and optionally ig_version) to download "
+        "from packages.fhir.org (e.g. hl7.fhir.us.core@6.1.0)."
     )
-    if not fhir_spec_directory:
+    use_registry_download = ig_name and ig_name.strip() and not fhir_spec_directory
+    if not fhir_spec_directory and not use_registry_download:
         return _log_output_and_return(
             tool_name="fhirPackageGeneration",
             request_id=_request_id,
             caller=_caller,
             response_str=format_error_output(
                 "fhirPackageGeneration",
-                "Missing definitions path",
+                "Missing definitions path or ig_name",
                 setup_hint
             ),
             start_time=_start_time,
         )
-    fhir_spec_directory = normalize_path(fhir_spec_directory)
+    if fhir_spec_directory:
+        fhir_spec_directory = normalize_path(fhir_spec_directory)
 
-    ws_err = _validate_within_workspace(fhir_spec_directory, "fhir_spec_directory")
-    if ws_err:
-        return _log_output_and_return(
-            tool_name="fhirPackageGeneration",
-            request_id=_request_id,
-            caller=_caller,
-            response_str=format_error_output("fhirPackageGeneration", "Validation error", ws_err),
-            start_time=_start_time,
-        )
+    if fhir_spec_directory:
+        ws_err = _validate_within_workspace(fhir_spec_directory, "fhir_spec_directory")
+        if ws_err:
+            return _log_output_and_return(
+                tool_name="fhirPackageGeneration",
+                request_id=_request_id,
+                caller=_caller,
+                response_str=format_error_output("fhirPackageGeneration", "Validation error", ws_err),
+                start_time=_start_time,
+            )
 
     # If definitions path doesn't exist, return concise setup guidance
-    if not os.path.exists(fhir_spec_directory):
+    if fhir_spec_directory and not os.path.exists(fhir_spec_directory):
         return _log_output_and_return(
             tool_name="fhirPackageGeneration",
             request_id=_request_id,
@@ -541,7 +544,7 @@ def fhirPackageGeneration(
             start_time=_start_time,
         )
     
-    if not os.path.isdir(fhir_spec_directory):
+    if fhir_spec_directory and not os.path.isdir(fhir_spec_directory):
         return _log_output_and_return(
             tool_name="fhirPackageGeneration",
             request_id=_request_id,
@@ -554,44 +557,55 @@ def fhirPackageGeneration(
             start_time=_start_time,
         )
     
-    # Check if directory contains files (not empty)
-    try:
-        files = os.listdir(fhir_spec_directory)
-        actual_files = [f for f in files if not f.startswith('.')]
-        if not actual_files:
+    if use_registry_download:
+        if not working_directory:
             return _log_output_and_return(
                 tool_name="fhirPackageGeneration",
                 request_id=_request_id,
                 caller=_caller,
                 response_str=format_error_output(
                     "fhirPackageGeneration",
-                    "Empty directory",
-                    f"Empty definitions at: {fhir_spec_directory}. {setup_hint}"
+                    "Validation error",
+                    "working_directory is required when downloading an IG via ig_name.",
                 ),
                 start_time=_start_time,
             )
-    except Exception as e:
-        return _log_output_and_return(
-            tool_name="fhirPackageGeneration",
-            request_id=_request_id,
-            caller=_caller,
-            response_str=format_error_output("fhirPackageGeneration", "Directory error", f"Error reading directory {fhir_spec_directory}: {e}"),
-            start_time=_start_time,
-        )
-    
-    # Auto-detect working_directory if not provided
-    if not working_directory:
-        # If path is like <project>/spec/<ig-name>, use <project> as working directory
-        path_parts = fhir_spec_directory.split(os.sep)
-        if 'spec' in path_parts:
-            spec_index = len(path_parts) - 1 - path_parts[::-1].index('spec')
-            working_directory = os.sep.join(path_parts[:spec_index])
-        else:
-            # Fallback: use parent directory
-            working_directory = os.path.dirname(fhir_spec_directory)
-    
-    # Normalize working directory
-    working_directory = normalize_path(working_directory)
+        working_directory = normalize_path(working_directory)
+    else:
+        try:
+            files = os.listdir(fhir_spec_directory)
+            actual_files = [f for f in files if not f.startswith('.')]
+            if not actual_files:
+                return _log_output_and_return(
+                    tool_name="fhirPackageGeneration",
+                    request_id=_request_id,
+                    caller=_caller,
+                    response_str=format_error_output(
+                        "fhirPackageGeneration",
+                        "Empty directory",
+                        f"Empty definitions at: {fhir_spec_directory}. {setup_hint}"
+                    ),
+                    start_time=_start_time,
+                )
+        except Exception as e:
+            return _log_output_and_return(
+                tool_name="fhirPackageGeneration",
+                request_id=_request_id,
+                caller=_caller,
+                response_str=format_error_output("fhirPackageGeneration", "Directory error", f"Error reading directory {fhir_spec_directory}: {e}"),
+                start_time=_start_time,
+            )
+
+        # Auto-detect working_directory if not provided
+        if not working_directory:
+            path_parts = fhir_spec_directory.split(os.sep)
+            if 'spec' in path_parts:
+                spec_index = len(path_parts) - 1 - path_parts[::-1].index('spec')
+                working_directory = os.sep.join(path_parts[:spec_index])
+            else:
+                working_directory = os.path.dirname(fhir_spec_directory)
+
+        working_directory = normalize_path(working_directory)
 
     ws_err = _validate_within_workspace(working_directory, "working_directory")
     if ws_err:
@@ -615,7 +629,7 @@ def fhirPackageGeneration(
 
     # Infer package name if not provided
     if not package_name or not package_name.strip():
-        base_candidate = ig_name or os.path.basename(fhir_spec_directory.rstrip('/\\'))
+        base_candidate = ig_name or (os.path.basename(fhir_spec_directory.rstrip('/\\')) if fhir_spec_directory else "")
         base = (base_candidate or "").lower()
         try:
             if "hl7.fhir.us.core" in base:
@@ -694,8 +708,11 @@ def fhirPackageGeneration(
     # Add optional organization name
     if org_name:
         cmd.extend(["--org-name", org_name])
-    
-    cmd.append(fhir_spec_directory)
+
+    _append_registry_ig_args(cmd, ig_name, ig_version)
+
+    if fhir_spec_directory:
+        cmd.append(fhir_spec_directory)
 
     disk_err = _check_disk_space(output_location, "fhirPackageGeneration", _request_id, _caller, _start_time)
     if disk_err:
@@ -761,11 +778,13 @@ def fhirPackageGeneration(
         )
 
 @mcp.tool(
-    description="Generate FHIR API templates from a FHIR Implementation Guide. Required: absolute path to definitions under spec/<ig_name>. If missing, install via npm and move to spec:<newline>npm --registry https://packages.simplifier.net install <ig_name><newline>Examples: US Core hl7.fhir.us.core@8.0.1, CARIN BB hl7.fhir.us.carin-bb@2.1.0, PDex hl7.fhir.us.davinci-pdex@2.1.0. Command: bal health fhir -m template --dependent-package <package> [--included-profile <url>]* [--excluded-profile <url>]* -o <output> <definitions_path>"
+    description="Generate FHIR API templates from a FHIR Implementation Guide. Use a local definitions path, --ig-name/--ig-version to download from packages.fhir.org, or omit both to use default hl7.fhir.r4.core. Command: bal health fhir -m template [--dependent-package <pkg>] [--ig-name <id> --ig-version <ver>] -o <output> [<definitions_path>]"
 )
 def fhirTemplateGeneration(
-    dependent_package: Annotated[str, "REQUIRED: Fully qualified Ballerina package (e.g., 'ballerinax/health.fhir.r4.uscore501', 'ballerinax/health.fhir.r4international401')"],
-    fhir_spec_directory: Annotated[str, "REQUIRED: Absolute path to FHIR IG definitions under spec/<ig_name>."] ,
+    dependent_package: Annotated[Optional[str], "Optional: Ballerina package (e.g. ballerinax/health.fhir.r4.uscore501). Inferred for known IGs or default R4 core."] = None,
+    fhir_spec_directory: Annotated[Optional[str], "Optional: Absolute path to FHIR IG definitions. Omit to download via ig_name or default hl7.fhir.r4.core."] = None,
+    ig_name: Annotated[Optional[str], "Optional: FHIR registry package id (e.g. hl7.fhir.us.core)."] = None,
+    ig_version: Annotated[Optional[str], "Optional: FHIR registry package version (e.g. 6.1.0). If omitted, bal health prompts interactively in a TTY; use --non-interactive in scripts for latest."] = None,
     working_directory: Annotated[Optional[str], "Optional: Project directory. Auto-detected from path if not provided."] = None,
     org_name: Annotated[Optional[str], "Optional: Organization name for generated templates"] = None,
     included_profiles: Annotated[Optional[list[str]], "Optional: FHIR profile URLs to ONLY include. Reduces generation time by skipping unwanted profiles."] = None,
@@ -776,17 +795,13 @@ def fhirTemplateGeneration(
     This tool generates Ballerina service templates based on FHIR profiles in an IG.
     Equivalent to: bal health fhir -m template -o <output> --org-name <org> --dependent-package <package> <definitions_path>
 
-    IMPORTANT: Both fhir_spec_directory (absolute definitions path) AND dependent_package are REQUIRED.
-    If definitions are not available locally, install via npm and move to spec:
-        npm --registry https://packages.simplifier.net install <ig_name>
-        Examples:
-            - US Core: hl7.fhir.us.core@8.0.1
-            - CARIN BB: hl7.fhir.us.carin-bb@2.1.0
-            - PDex: hl7.fhir.us.davinci-pdex@2.1.0
+    Provide a local path, ig_name/ig_version for registry download, or neither for default HL7 R4 core templates.
 
     Args:
-        fhir_spec_directory: Required. Absolute path to FHIR IG definitions under spec/<ig_name>.
-        dependent_package: Required. Fully qualified Ballerina package name (e.g., 'ballerinax/health.fhir.r4.uscore501').
+        fhir_spec_directory: Optional. Absolute path to FHIR IG definitions.
+        dependent_package: Optional. Fully qualified Ballerina package name.
+        ig_name: Optional. Registry package id.
+        ig_version: Optional. Registry package version.
         working_directory: Optional. Auto-detected from path; if definitions path is <project>/spec/<ig-name>, uses <project>.
         org_name: Optional. Organization name for generated templates (e.g., 'healthcare_samples').
         included_profiles: Optional. List of FHIR profile URLs to ONLY include in generation.
@@ -802,26 +817,11 @@ def fhirTemplateGeneration(
 
     # Resolve inputs: require absolute definitions path under spec/<ig_name>
     setup_hint = (
-        "Place IG definitions under spec/<ig_name> and provide the absolute path.\n"
-        "If not available, install via npm and move to spec:\n"
-        "npm --registry https://packages.simplifier.net install <ig_name>\n"
-        "Examples: US Core hl7.fhir.us.core@8.0.1, CARIN BB hl7.fhir.us.carin-bb@2.1.0, PDex hl7.fhir.us.davinci-pdex@2.1.0"
-        "\nAfter moving files, provide the absolute path to the definitions again to generate the templates."
-        "\nProvide user with the above instructions only keeping the message short and clear."
+        "Provide fhir_spec_directory, ig_name/ig_version for registry download, or omit both for default R4 core."
     )
 
-    # Validate dependent package
-    if not dependent_package or not dependent_package.strip():
-        return _log_output_and_return(
-            tool_name="fhirTemplateGeneration",
-            request_id=_request_id,
-            caller=_caller,
-            response_str=format_error_output("fhirTemplateGeneration", "Validation error", "dependent_package is required (e.g., ballerinax/health.fhir.r4.uscore501)"),
-            start_time=_start_time,
-        )
-
-    # Validate required spec path
-    if not fhir_spec_directory:
+    use_registry_download = (ig_name and ig_name.strip()) or not fhir_spec_directory
+    if not fhir_spec_directory and not use_registry_download:
         return _log_output_and_return(
             tool_name="fhirTemplateGeneration",
             request_id=_request_id,
@@ -834,9 +834,11 @@ def fhirTemplateGeneration(
             start_time=_start_time,
         )
 
-    fhir_spec_directory = normalize_path(fhir_spec_directory)
+    if fhir_spec_directory:
+        fhir_spec_directory = normalize_path(fhir_spec_directory)
 
-    ws_err = _validate_within_workspace(fhir_spec_directory, "fhir_spec_directory")
+    if fhir_spec_directory:
+        ws_err = _validate_within_workspace(fhir_spec_directory, "fhir_spec_directory")
     if ws_err:
         return _log_output_and_return(
             tool_name="fhirTemplateGeneration",
@@ -846,8 +848,7 @@ def fhirTemplateGeneration(
             start_time=_start_time,
         )
 
-    # If definitions path doesn't exist, return concise setup guidance
-    if not os.path.exists(fhir_spec_directory):
+    if fhir_spec_directory and not os.path.exists(fhir_spec_directory):
         return _log_output_and_return(
             tool_name="fhirTemplateGeneration",
             request_id=_request_id,
@@ -860,7 +861,56 @@ def fhirTemplateGeneration(
             start_time=_start_time,
         )
 
-    if not os.path.isdir(fhir_spec_directory):
+    if fhir_spec_directory:
+        if not os.path.isdir(fhir_spec_directory):
+            return _log_output_and_return(
+                tool_name="fhirTemplateGeneration",
+                request_id=_request_id,
+                caller=_caller,
+                response_str=format_error_output(
+                    "fhirTemplateGeneration",
+                    "Validation error",
+                    f"Not a directory: {fhir_spec_directory}. {setup_hint}",
+                ),
+                start_time=_start_time,
+            )
+
+        try:
+            files = os.listdir(fhir_spec_directory)
+            actual_files = [f for f in files if not f.startswith('.')]
+            if not actual_files:
+                return _log_output_and_return(
+                    tool_name="fhirTemplateGeneration",
+                    request_id=_request_id,
+                    caller=_caller,
+                    response_str=format_error_output(
+                        "fhirTemplateGeneration",
+                        "Empty directory",
+                        f"Empty definitions at: {fhir_spec_directory}. {setup_hint}",
+                    ),
+                    start_time=_start_time,
+                )
+        except Exception as e:
+            return _log_output_and_return(
+                tool_name="fhirTemplateGeneration",
+                request_id=_request_id,
+                caller=_caller,
+                response_str=format_error_output(
+                    "fhirTemplateGeneration",
+                    "Directory error",
+                    f"Error reading directory {fhir_spec_directory}: {e}",
+                ),
+                start_time=_start_time,
+            )
+
+        if not working_directory:
+            path_parts = fhir_spec_directory.split(os.sep)
+            if 'spec' in path_parts:
+                spec_index = len(path_parts) - 1 - path_parts[::-1].index('spec')
+                working_directory = os.sep.join(path_parts[:spec_index])
+            else:
+                working_directory = os.path.dirname(fhir_spec_directory)
+    elif not working_directory:
         return _log_output_and_return(
             tool_name="fhirTemplateGeneration",
             request_id=_request_id,
@@ -868,52 +918,11 @@ def fhirTemplateGeneration(
             response_str=format_error_output(
                 "fhirTemplateGeneration",
                 "Validation error",
-                f"Not a directory: {fhir_spec_directory}. {setup_hint}",
+                "working_directory is required when using registry download without a local definitions path.",
             ),
             start_time=_start_time,
         )
 
-    # Check if directory contains files (not empty)
-    try:
-        files = os.listdir(fhir_spec_directory)
-        actual_files = [f for f in files if not f.startswith('.')]
-        if not actual_files:
-            return _log_output_and_return(
-                tool_name="fhirTemplateGeneration",
-                request_id=_request_id,
-                caller=_caller,
-                response_str=format_error_output(
-                    "fhirTemplateGeneration",
-                    "Empty directory",
-                    f"Empty definitions at: {fhir_spec_directory}. {setup_hint}",
-                ),
-                start_time=_start_time,
-            )
-    except Exception as e:
-        return _log_output_and_return(
-            tool_name="fhirTemplateGeneration",
-            request_id=_request_id,
-            caller=_caller,
-            response_str=format_error_output(
-                "fhirTemplateGeneration",
-                "Directory error",
-                f"Error reading directory {fhir_spec_directory}: {e}",
-            ),
-            start_time=_start_time,
-        )
-
-    # Auto-detect working_directory if not provided
-    if not working_directory:
-        # If path is like <project>/spec/<ig-name>, use <project> as working directory
-        path_parts = fhir_spec_directory.split(os.sep)
-        if 'spec' in path_parts:
-            spec_index = len(path_parts) - 1 - path_parts[::-1].index('spec')
-            working_directory = os.sep.join(path_parts[:spec_index])
-        else:
-            # Fallback: use parent directory
-            working_directory = os.path.dirname(fhir_spec_directory)
-
-    # Normalize working directory
     working_directory = normalize_path(working_directory)
 
     ws_err = _validate_within_workspace(working_directory, "working_directory")
@@ -1003,15 +1012,17 @@ def fhirTemplateGeneration(
     cmd = [
         bal_exe, "health", "fhir",
         "--mode", "template",
-        "--dependent-package", dependent_package,
     ]
 
-    # Output location (always set, defaulted above)
+    if dependent_package and dependent_package.strip():
+        cmd.extend(["--dependent-package", dependent_package.strip()])
+
     cmd.extend(["--output", output_location])
 
-    # Add optional organization name
     if org_name:
         cmd.extend(["--org-name", org_name])
+
+    _append_registry_ig_args(cmd, ig_name, ig_version)
 
     # Add included profiles (can be specified multiple times)
     if included_profiles:
@@ -1022,8 +1033,9 @@ def fhirTemplateGeneration(
     if excluded_profiles:
         for profile in excluded_profiles:
             cmd.extend(["--excluded-profile", profile])
-    cmd.extend(["--aggregate","--minimal"])
-    cmd.append(fhir_spec_directory)
+    cmd.extend(["--aggregate", "--minimal"])
+    if fhir_spec_directory:
+        cmd.append(fhir_spec_directory)
 
     disk_err = _check_disk_space(output_location, "fhirTemplateGeneration", _request_id, _caller, _start_time)
     if disk_err:

--- a/native/cds-bal-template/pom.xml
+++ b/native/cds-bal-template/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>cds-bal-template</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <dependencies>
         <dependency>

--- a/native/fhir-to-bal-connector/pom.xml
+++ b/native/fhir-to-bal-connector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/native/fhir-to-bal-lib/pom.xml
+++ b/native/fhir-to-bal-lib/pom.xml
@@ -25,12 +25,12 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>fhir-to-bal-lib</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <dependencies>
         <dependency>

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r4/R4ResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r4/R4ResourceContextGenerator.java
@@ -338,20 +338,21 @@ public class R4ResourceContextGenerator extends AbstractResourceContextGenerator
         List<CanonicalType> profiles = type.getProfile();
         if (!profiles.isEmpty()) {
             for (CanonicalType profile : profiles) {
-                String profileType = CommonUtil.getSplitTokenAt(profile.getValue(), "/", ToolConstants.TokenPosition.END);
+                String profileUrl = CommonUtil.stripCanonicalVersion(profile.getValue());
+                String profileType = CommonUtil.getSplitTokenAt(profileUrl, "/", ToolConstants.TokenPosition.END);
                 profileType = GeneratorUtils.getInstance().getUniqueIdentifierFromId(profileType);
-                if (getDatatypeTemplateContextMap().containsKey(profile.getValue())) {
-                    element.addProfile(profile.getValue(), profileType);
+                if (getDatatypeTemplateContextMap().containsKey(profileUrl)) {
+                    element.addProfile(profileUrl, profileType);
                     DataTypesRegistry.getInstance().addDataType(profileType);
                 } else {
-                    element.addProfile(profile.getValue(), profileType);
+                    element.addProfile(profileUrl, profileType);
                 }
                 //check for prefix when non R4 profiles are available
                 for (String dependentIgUrl : getToolConfig().getPackageConfig().getDependentIgs().keySet()) {
-                    if (profile.getValue().startsWith(dependentIgUrl)) {
+                    if (profileUrl.startsWith(dependentIgUrl)) {
                         String dependentIgPackageName = getToolConfig().getPackageConfig().getDependentIgs().get(dependentIgUrl);
                         String dependentIgPackagePrefix = CommonUtil.getSplitTokenAt(dependentIgPackageName, "\\.", ToolConstants.TokenPosition.END);
-                        element.getProfiles().get(profile.getValue()).setPrefix(dependentIgPackagePrefix);
+                        element.getProfiles().get(profileUrl).setPrefix(dependentIgPackagePrefix);
                     }
                 }
             }

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r5/R5ResourceContextGenerator.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/modelgen/versions/r5/R5ResourceContextGenerator.java
@@ -360,21 +360,22 @@ public class R5ResourceContextGenerator extends AbstractResourceContextGenerator
         List<CanonicalType> profiles = type.getProfile();
         if (!profiles.isEmpty()) {
             for (CanonicalType profile : profiles) {
-                String profileType = CommonUtil.getSplitTokenAt(profile.getValue(), "/", ToolConstants.TokenPosition.END);
+                String profileUrl = CommonUtil.stripCanonicalVersion(profile.getValue());
+                String profileType = CommonUtil.getSplitTokenAt(profileUrl, "/", ToolConstants.TokenPosition.END);
                 profileType = GeneratorUtils.getInstance().getUniqueIdentifierFromId(profileType);
 
-                if (getDatatypeTemplateContextMap().containsKey(profile.getValue())) {
-                    element.addProfile(profile.getValue(), profileType);
+                if (getDatatypeTemplateContextMap().containsKey(profileUrl)) {
+                    element.addProfile(profileUrl, profileType);
                     DataTypesRegistry.getInstance().addDataType(profileType);
                 } else {
-                    element.addProfile(profile.getValue(), profileType);
+                    element.addProfile(profileUrl, profileType);
                 }
                 //check for prefix when non R5 profiles are available
                 for (String dependentIgUrl : getToolConfig().getPackageConfig().getDependentIgs().keySet()) {
-                    if (profile.getValue().startsWith(dependentIgUrl)) {
+                    if (profileUrl.startsWith(dependentIgUrl)) {
                         String dependentIgPackageName = getToolConfig().getPackageConfig().getDependentIgs().get(dependentIgUrl);
                         String dependentIgPackagePrefix = CommonUtil.getSplitTokenAt(dependentIgPackageName, "\\.", ToolConstants.TokenPosition.END);
-                        element.getProfiles().get(profile.getValue()).setPrefix(dependentIgPackagePrefix);
+                        element.getProfiles().get(profileUrl).setPrefix(dependentIgPackagePrefix);
                     }
                 }
             }

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/CommonUtil.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/CommonUtil.java
@@ -74,6 +74,17 @@ public class CommonUtil {
      * @param tokenPosition position of the preferred token
      * @return preferred token
      */
+    /**
+     * Removes the version suffix from a FHIR canonical URL ({@code url|version}).
+     */
+    public static String stripCanonicalVersion(String canonical) {
+        if (canonical == null || canonical.isEmpty()) {
+            return canonical;
+        }
+        int versionSeparator = canonical.indexOf('|');
+        return versionSeparator >= 0 ? canonical.substring(0, versionSeparator) : canonical;
+    }
+
     public static String getSplitTokenAt(String string, String delimiter, ToolConstants.TokenPosition tokenPosition) {
         String[] tokens = string.split(delimiter);
         int position = 0;

--- a/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/GeneratorUtils.java
+++ b/native/fhir-to-bal-lib/src/main/java/org/wso2/healthcare/fhir/ballerina/packagegen/tool/utils/GeneratorUtils.java
@@ -400,6 +400,7 @@ public class GeneratorUtils {
     }
 
     public String getUniqueIdentifierFromId(String id) {
+        id = CommonUtil.stripCanonicalVersion(id);
         id = id.replace("StructureDefinition", "");
         StringBuilder uniqueIdentifier = new StringBuilder();
         String[] idTokens = id.split("-");

--- a/native/fhir-to-bal-template/pom.xml
+++ b/native/fhir-to-bal-template/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>fhir-to-bal-template</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <dependencies>
         <dependency>

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/AbstractBallerinaProjectTool.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/AbstractBallerinaProjectTool.java
@@ -112,28 +112,41 @@ public abstract class AbstractBallerinaProjectTool extends AbstractFHIRTool {
      */
     protected void populateIGs(ToolContext toolContext) {
 
+        // Multi-IG runs (2+ IncludedIGConfig entries, one per real --ig name -- see FhirTemplateGenHandler) must
+        // keep each IG keyed by its own real name and leave its importStatement alone: it already carries that
+        // IG's own resolved package (packageMappings, enforced non-null for multi-IG). Collapsing every IG onto
+        // the single shared packageName/igPackage below -- as single-IG mode does -- would make a second IG
+        // silently overwrite the first in igMap.
+        boolean isMultiIG = getBallerinaProjectToolConfig().getIncludedIGConfigs().size() > 1;
+
         for (Map.Entry<String, IncludedIGConfig> entry : getBallerinaProjectToolConfig().getIncludedIGConfigs().entrySet()) {
             String igName = entry.getKey();
             FHIRImplementationGuide ig = ((FHIRSpecificationData) toolContext.getSpecificationData()).
                     getFhirImplementationGuides().get(igName);
-            String packageName = getBallerinaProjectToolConfig().getVersionConfig().getNamePrefix();
-            if (entry.getValue().isEnable() && ig != null) {
-                String igPackage = getBallerinaProjectToolConfig().getMetadataConfig().getOrg() + "/" +
-                        getBallerinaProjectToolConfig().getVersionConfig().getNamePrefix();
-                igMap.put(packageName, ig);
-
-                if (!packageName.equals(igName)) {
-                    //Update key in the ig config global map
-                    getBallerinaProjectToolConfig().getIncludedIGConfigs().remove(igName);
-                    IncludedIGConfig updatedIGConfig = entry.getValue();
-                    updatedIGConfig.setImportStatement(igPackage);
-                    getBallerinaProjectToolConfig().getIncludedIGConfigs().put(packageName, updatedIGConfig);
-
-                    ((FHIRSpecificationData) toolContext.getSpecificationData()).getFhirImplementationGuides().remove(igName);
-                    ((FHIRSpecificationData) toolContext.getSpecificationData()).getFhirImplementationGuides().put(packageName, ig);
-                }
-                dependenciesMap.put("igPackage", igPackage);
+            if (!entry.getValue().isEnable() || ig == null) {
+                continue;
             }
+            if (isMultiIG) {
+                igMap.put(igName, ig);
+                dependenciesMap.put("igPackage", entry.getValue().getImportStatement());
+                continue;
+            }
+            String packageName = getBallerinaProjectToolConfig().getVersionConfig().getNamePrefix();
+            String igPackage = getBallerinaProjectToolConfig().getMetadataConfig().getOrg() + "/" +
+                    getBallerinaProjectToolConfig().getVersionConfig().getNamePrefix();
+            igMap.put(packageName, ig);
+
+            if (!packageName.equals(igName)) {
+                //Update key in the ig config global map
+                getBallerinaProjectToolConfig().getIncludedIGConfigs().remove(igName);
+                IncludedIGConfig updatedIGConfig = entry.getValue();
+                updatedIGConfig.setImportStatement(igPackage);
+                getBallerinaProjectToolConfig().getIncludedIGConfigs().put(packageName, updatedIGConfig);
+
+                ((FHIRSpecificationData) toolContext.getSpecificationData()).getFhirImplementationGuides().remove(igName);
+                ((FHIRSpecificationData) toolContext.getSpecificationData()).getFhirImplementationGuides().put(packageName, ig);
+            }
+            dependenciesMap.put("igPackage", igPackage);
         }
     }
 

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/AbstractBallerinaProjectTool.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/AbstractBallerinaProjectTool.java
@@ -183,6 +183,10 @@ public abstract class AbstractBallerinaProjectTool extends AbstractFHIRTool {
         dependenciesMap.put("basePackage", fhirBaseImportStatement.toLowerCase());
         dependenciesMap.put("servicePackage", fhirServiceImportStatement.toLowerCase());
         dependenciesMap.put("dependentPackage", fhirInternationalImportStatement.toLowerCase());
+        dependenciesMap.put("useGenerateIgModule",
+                String.valueOf(getBallerinaProjectToolConfig().isGenerateIgModuleEnabled()));
+        dependenciesMap.put("generateIgModuleName",
+                getBallerinaProjectToolConfig().getGenerateIgModuleName());
     }
 
     protected abstract void populateBalService();

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/BallerinaProjectConstants.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/BallerinaProjectConstants.java
@@ -18,6 +18,8 @@
 
 package org.wso2.healthcare.fhir.codegen.ballerina.project.tool;
 
+import java.time.LocalDate;
+
 /**
  * Constants for Ballerina Project Gen tool
  */
@@ -28,6 +30,7 @@ public class BallerinaProjectConstants {
     public static final String PROJECT_API_SUFFIX = ".api";
     public static final String YAML_FILE_EXTENSION = ".yaml";
     public static final String RESOURCE_PATH_SEPERATOR = "/";
+    public static final String LICENSE_YEAR = String.valueOf(LocalDate.now().getYear());
 
     public class PrintStrings {
 

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
@@ -53,6 +53,7 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     private boolean enableAggregatedApi;
     private List<String> aggregatedApis;
     private boolean minimalGeneration;
+    private boolean flatOutput;
     private boolean generateIgModuleEnabled;
     private String generateIgModuleName;
     private String generateIgModuleSourceDir;
@@ -133,6 +134,9 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
                 break;
             case "project.minimalGeneration":
                 this.minimalGeneration = value.getAsBoolean();
+                break;
+            case "project.flatOutput":
+                this.flatOutput = value.getAsBoolean();
                 break;
             case "project.aggregatedApis":
                 this.aggregatedApis.clear();
@@ -257,6 +261,8 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     }
 
     public boolean isMinimalGeneration() { return minimalGeneration;}
+
+    public boolean isFlatOutput() { return flatOutput;}
 
     public boolean isGenerateIgModuleEnabled() {
         return generateIgModuleEnabled;

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
@@ -53,6 +53,9 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     private boolean enableAggregatedApi;
     private List<String> aggregatedApis;
     private boolean minimalGeneration;
+    private boolean generateIgModuleEnabled;
+    private String generateIgModuleName;
+    private String generateIgModuleSourceDir;
 
     public BallerinaProjectToolConfig() {
         this.aggregatedApis = new ArrayList<>();
@@ -86,6 +89,17 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
             }
             if (jsonConfigObj.getAsJsonArray("aggregatedApis") != null) {
                 populateAggregatedApis(jsonConfigObj.getAsJsonArray("aggregatedApis"));
+            }
+            if (jsonConfigObj.getAsJsonObject("generateIgModule") != null) {
+                JsonObject generateIgModuleConfig = jsonConfigObj.getAsJsonObject("generateIgModule");
+                if (generateIgModuleConfig.getAsJsonPrimitive("enabled") != null) {
+                    this.generateIgModuleEnabled = generateIgModuleConfig
+                            .getAsJsonPrimitive("enabled").getAsBoolean();
+                }
+                if (generateIgModuleConfig.getAsJsonPrimitive("name") != null) {
+                    this.generateIgModuleName = generateIgModuleConfig
+                            .getAsJsonPrimitive("name").getAsString();
+                }
             }
         }
         //todo: add toml type config handling
@@ -128,6 +142,15 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
                         this.aggregatedApis.add(resourcesArray.get(i).getAsString());
                     }
                 }
+                break;
+            case "project.generateIgModule.enabled":
+                this.generateIgModuleEnabled = value.getAsBoolean();
+                break;
+            case "project.generateIgModule.name":
+                this.generateIgModuleName = value.getAsString();
+                break;
+            case "project.generateIgModule.sourceDir":
+                this.generateIgModuleSourceDir = value.getAsString();
                 break;
             default:
                 LOG.warn("Invalid config path: " + jsonPath);
@@ -234,4 +257,16 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     }
 
     public boolean isMinimalGeneration() { return minimalGeneration;}
+
+    public boolean isGenerateIgModuleEnabled() {
+        return generateIgModuleEnabled;
+    }
+
+    public String getGenerateIgModuleName() {
+        return generateIgModuleName;
+    }
+
+    public String getGenerateIgModuleSourceDir() {
+        return generateIgModuleSourceDir;
+    }
 }

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/config/BallerinaProjectToolConfig.java
@@ -54,6 +54,7 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     private List<String> aggregatedApis;
     private boolean minimalGeneration;
     private boolean flatOutput;
+    private String templatePackageName;
     private boolean generateIgModuleEnabled;
     private String generateIgModuleName;
     private String generateIgModuleSourceDir;
@@ -137,6 +138,9 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
                 break;
             case "project.flatOutput":
                 this.flatOutput = value.getAsBoolean();
+                break;
+            case "project.package.templateName":
+                this.templatePackageName = value.getAsString();
                 break;
             case "project.aggregatedApis":
                 this.aggregatedApis.clear();
@@ -263,6 +267,15 @@ public class BallerinaProjectToolConfig extends AbstractToolConfig {
     public boolean isMinimalGeneration() { return minimalGeneration;}
 
     public boolean isFlatOutput() { return flatOutput;}
+
+    /**
+     * Aggregated-mode project name (Ballerina.toml's name, and the import prefix for an embedded IG
+     * module). Defaults to "FHIRServerTemplate" when --package-name isn't given, matching prior behavior.
+     */
+    public String getTemplatePackageName() {
+        return (templatePackageName != null && !templatePackageName.isEmpty())
+                ? templatePackageName : "FHIRServerTemplate";
+    }
 
     public boolean isGenerateIgModuleEnabled() {
         return generateIgModuleEnabled;

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/AggregatedServiceGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/AggregatedServiceGenerator.java
@@ -66,6 +66,7 @@ public class AggregatedServiceGenerator extends AbstractFHIRTemplateGenerator {
         AggregatedService aggregatedService = initializeAggregatedServiceWithDefaults(generatorProperties);
         
         templateContext.setProperty("aggregatedService", aggregatedService);
+        templateContext.setProperty("licenseYear", BallerinaProjectConstants.LICENSE_YEAR);
         templateContext.setProperty("basePackageImportIdentifier", generatorProperties.get("basePackageImportIdentifier"));
         templateContext.setProperty("servicePackageImportIdentifier", generatorProperties.get("servicePackageImportIdentifier"));
         templateContext.setProperty("dependentPackageImportIdentifier", generatorProperties.get("dependentPackageImportIdentifier"));

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/AggregatedServiceGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/AggregatedServiceGenerator.java
@@ -25,6 +25,8 @@ import org.wso2.healthcare.codegen.tool.framework.fhir.core.AbstractFHIRTemplate
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.BallerinaProjectConstants;
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.config.BallerinaProjectToolConfig;
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.AggregatedService;
+import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.BallerinaService;
+import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.FHIRProfile;
 
 import java.io.File;
 import java.util.HashMap;
@@ -55,7 +57,27 @@ public class AggregatedServiceGenerator extends AbstractFHIRTemplateGenerator {
         
         aggregatedService.addImport(dependencies.get("basePackage"));
         aggregatedService.addImport(dependencies.get("servicePackage"));
-        aggregatedService.addImport(dependencies.get("dependentPackage"));
+        if (ballerinaProjectToolConfig.getIncludedIGConfigs().size() <= 1) {
+            // Multi-IG: every profile already resolves to its own package via the loop below: nothing in the
+            // generated service references the tool-wide default, so importing it here would be an unused
+            // import (a Ballerina compile error, not just a warning).
+            aggregatedService.addImport(dependencies.get("dependentPackage"));
+        }
+        // Only multi-IG needs per-profile imports (each IG keeps its own real name/importStatement -- see
+        // AbstractBallerinaProjectTool.populateIGs()). For a single IncludedIGConfig entry,
+        // profile.getImportsList() is unreliable regardless of embed vs. explicit dependent package:
+        // populateIGs() rewrites that IG's importStatement to <project org>/<versionConfig namePrefix>, which
+        // is a different string (different org, or a local-module path) than the correct, already-added
+        // dependencies.get("dependentPackage") -- adding it too causes a duplicate/conflicting import.
+        if (ballerinaProjectToolConfig.getIncludedIGConfigs().size() > 1) {
+            for (BallerinaService service : aggregatedService.getServices().values()) {
+                for (FHIRProfile profile : service.getProfileList()) {
+                    for (Object importStatement : profile.getImportsList()) {
+                        aggregatedService.addImport((String) importStatement);
+                    }
+                }
+            }
+        }
         aggregatedService.setOperationConfigs(ballerinaProjectToolConfig.getOperationConfig());
         
         return aggregatedService;

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
@@ -27,12 +27,15 @@ import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.AggregatedS
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.BallerinaService;
 
 import java.io.Console;
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.stream.Stream;
 
 /**
  * Generator class to wrap all the generator classes in Ballerina project generator.
@@ -53,9 +56,9 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
         //evaluate usage of ? typed map as generator properties.
 
         String packagePath = this.getTargetDir();
-        // Provide option to check and overwrite the existing package
+        // Provide option to check and overwrite existing template output (not staging dirs alone)
         Console console = System.console();
-        if (console != null && Files.exists(Paths.get(packagePath))) {
+        if (console != null && hasExistingGeneratedTemplates(packagePath, ballerinaProjectToolConfig, serviceMap)) {
             String input = console.readLine("Generated templates already exists. Do you want to overwrite? (y/n): ");
             if ("n".equalsIgnoreCase(input)) {
                 System.exit(0);
@@ -76,15 +79,24 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
                 projectProperties.put("config", ballerinaProjectToolConfig);
                 projectProperties.put("dependencies", dependenciesMap);
 
+                String projectAPIPath = this.getTargetDir() + entry.getKey().toLowerCase();
+                String templateName = ballerinaProjectToolConfig.getVersionConfig().getNamePrefix() + "." +
+                        entry.getKey().toLowerCase();
                 String basePackage = dependenciesMap.get("basePackage");
                 String servicePackage = dependenciesMap.get("servicePackage");
                 String igPackage = dependenciesMap.get("igPackage");
-                String dependentPackage = dependenciesMap.get("dependentPackage");
-                projectProperties.put("basePackageImportIdentifier", basePackage.substring(basePackage.lastIndexOf(".") + 1));
-                projectProperties.put("servicePackageImportIdentifier", servicePackage.substring(servicePackage.lastIndexOf(".") + 1));
-                projectProperties.put("igPackageImportIdentifier", igPackage.substring(igPackage.lastIndexOf(".") + 1));
-                projectProperties.put("dependentPackageImportIdentifier", dependentPackage.substring(dependentPackage.lastIndexOf(".") + 1));
-                projectProperties.put("projectAPIPath", this.getTargetDir() + entry.getKey().toLowerCase());
+                String dependentPackage = resolveDependentPackageImport(
+                        ballerinaProjectToolConfig, dependenciesMap, templateName);
+                dependenciesMap.put("dependentPackage", dependentPackage);
+                projectProperties.put("basePackageImportIdentifier", getImportIdentifier(basePackage));
+                projectProperties.put("servicePackageImportIdentifier", getImportIdentifier(servicePackage));
+                projectProperties.put("igPackageImportIdentifier", getImportIdentifier(igPackage));
+                projectProperties.put("dependentPackageImportIdentifier", getImportIdentifier(dependentPackage));
+                projectProperties.put("projectAPIPath", projectAPIPath);
+
+                if (ballerinaProjectToolConfig.isGenerateIgModuleEnabled()) {
+                    generateIgModule(projectAPIPath, ballerinaProjectToolConfig, serviceMap, null);
+                }
 
                 ServiceGenerator balServiceGenerator = new ServiceGenerator(this.getTargetDir());
                 balServiceGenerator.generate(toolContext, projectProperties);
@@ -112,17 +124,24 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
                 String basePackage = dependenciesMap.get("basePackage");
                 String servicePackage = dependenciesMap.get("servicePackage");
                 String igPackage = dependenciesMap.get("igPackage");
-                String dependentPackage = dependenciesMap.get("dependentPackage");
-                projectProperties.put("basePackageImportIdentifier", basePackage.substring(basePackage.lastIndexOf(".") + 1));
-                projectProperties.put("servicePackageImportIdentifier", servicePackage.substring(servicePackage.lastIndexOf(".") + 1));
-                projectProperties.put("igPackageImportIdentifier", igPackage.substring(igPackage.lastIndexOf(".") + 1));
-                projectProperties.put("dependentPackageImportIdentifier", dependentPackage.substring(dependentPackage.lastIndexOf(".") + 1));
+                String templateName = "FHIRServerTemplate";
+                String dependentPackage = resolveDependentPackageImport(
+                        ballerinaProjectToolConfig, dependenciesMap, templateName);
+                dependenciesMap.put("dependentPackage", dependentPackage);
+                projectProperties.put("basePackageImportIdentifier", getImportIdentifier(basePackage));
+                projectProperties.put("servicePackageImportIdentifier", getImportIdentifier(servicePackage));
+                projectProperties.put("igPackageImportIdentifier", getImportIdentifier(igPackage));
+                projectProperties.put("dependentPackageImportIdentifier", getImportIdentifier(dependentPackage));
 
                 // Use minimal generation flag to determine path
                 if (ballerinaProjectToolConfig.isMinimalGeneration()) {
                     projectProperties.put("projectAPIPath", this.getTargetDir());
                 } else {
                     projectProperties.put("projectAPIPath", this.getTargetDir() + "fhir-service");
+                }
+                if (ballerinaProjectToolConfig.isGenerateIgModuleEnabled()) {
+                    generateIgModule(projectProperties.get("projectAPIPath").toString(),
+                            ballerinaProjectToolConfig, serviceMap, entry.getValue());
                 }
 
                 AggregatedServiceGenerator aggregatedServiceGenerator = new AggregatedServiceGenerator(this.getTargetDir());
@@ -157,6 +176,93 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
                     componentYamlGenerator.generate(toolContext, projectProperties);
                 }
             }
+        }
+    }
+
+    private boolean hasExistingGeneratedTemplates(String packagePath, BallerinaProjectToolConfig config,
+                                                Map<String, BallerinaService> serviceMap) {
+        Path basePath = Paths.get(packagePath);
+        if (!Files.isDirectory(basePath)) {
+            return false;
+        }
+        if (config.isEnableAggregatedApi()) {
+            Path projectPath = config.isMinimalGeneration() ? basePath : basePath.resolve("fhir-service");
+            return Files.exists(projectPath.resolve("service.bal"));
+        }
+        if (serviceMap == null || serviceMap.isEmpty()) {
+            return false;
+        }
+        for (String resourceType : serviceMap.keySet()) {
+            if (Files.exists(basePath.resolve(resourceType.toLowerCase()).resolve("service.bal"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String resolveDependentPackageImport(BallerinaProjectToolConfig config, Map<String, String> dependenciesMap,
+                                                 String templateName) {
+        if (!config.isGenerateIgModuleEnabled()) {
+            return dependenciesMap.get("dependentPackage");
+        }
+        String igModuleName = config.getGenerateIgModuleName();
+        return templateName + "." + igModuleName;
+    }
+
+    private String getImportIdentifier(String importStatement) {
+        if (importStatement == null || importStatement.isEmpty()) {
+            return "";
+        }
+        int slashIndex = importStatement.lastIndexOf('/');
+        String modulePath = slashIndex >= 0 ? importStatement.substring(slashIndex + 1) : importStatement;
+        int dotIndex = modulePath.lastIndexOf('.');
+        return dotIndex >= 0 ? modulePath.substring(dotIndex + 1) : modulePath;
+    }
+
+    private void generateIgModule(String projectAPIPath, BallerinaProjectToolConfig config,
+                                  Map<String, BallerinaService> serviceMap,
+                                  AggregatedService aggregatedService) throws CodeGenException {
+        String igModuleName = config.getGenerateIgModuleName();
+        if (igModuleName == null || igModuleName.isEmpty()) {
+            return;
+        }
+        Path modulePath = Paths.get(projectAPIPath, "modules", igModuleName);
+        try {
+            Files.createDirectories(modulePath);
+        } catch (IOException e) {
+            throw new CodeGenException("Error creating IG module directory: " + e.getMessage(), e);
+        }
+        String generateIgModuleSourceDir = config.getGenerateIgModuleSourceDir();
+        if (generateIgModuleSourceDir == null || generateIgModuleSourceDir.isEmpty()) {
+            throw new CodeGenException("IG module source directory is not set.");
+        }
+        Path sourceDirectory = Paths.get(generateIgModuleSourceDir);
+        try {
+            try (Stream<Path> sourceFiles = Files.walk(sourceDirectory)) {
+                sourceFiles
+                        .filter(path -> !Files.isDirectory(path))
+                        .filter(path -> path.toString().endsWith(".bal")
+                                || path.toString().endsWith("Package.md")
+                                || path.toString().contains("resources" + java.io.File.separator))
+                        .forEach(path -> {
+                            Path relativePath = sourceDirectory.relativize(path);
+                            Path destination = modulePath.resolve(relativePath);
+                            try {
+                                Files.createDirectories(destination.getParent());
+                                Files.copy(path, destination, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+            }
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof IOException) {
+                throw new CodeGenException("Error generating IG module: " + e.getCause().getMessage(),
+                        e.getCause());
+            }
+            throw e;
+        } catch (IOException e) {
+            throw new CodeGenException("Error generating IG module: " + e.getMessage(), e);
         }
     }
 }

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
@@ -124,7 +124,7 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
                 String basePackage = dependenciesMap.get("basePackage");
                 String servicePackage = dependenciesMap.get("servicePackage");
                 String igPackage = dependenciesMap.get("igPackage");
-                String templateName = "FHIRServerTemplate";
+                String templateName = ballerinaProjectToolConfig.getTemplatePackageName();
                 String dependentPackage = resolveDependentPackageImport(
                         ballerinaProjectToolConfig, dependenciesMap, templateName);
                 dependenciesMap.put("dependentPackage", dependentPackage);

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/BallerinaProjectGenerator.java
@@ -133,8 +133,9 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
                 projectProperties.put("igPackageImportIdentifier", getImportIdentifier(igPackage));
                 projectProperties.put("dependentPackageImportIdentifier", getImportIdentifier(dependentPackage));
 
-                // Use minimal generation flag to determine path
-                if (ballerinaProjectToolConfig.isMinimalGeneration()) {
+                // Minimal and --flat both skip the fhir-service/ nesting; minimal additionally skips
+                // Ballerina.toml, OAS, .choreo, and .gitignore generation below.
+                if (ballerinaProjectToolConfig.isMinimalGeneration() || ballerinaProjectToolConfig.isFlatOutput()) {
                     projectProperties.put("projectAPIPath", this.getTargetDir());
                 } else {
                     projectProperties.put("projectAPIPath", this.getTargetDir() + "fhir-service");
@@ -186,7 +187,8 @@ public class BallerinaProjectGenerator extends AbstractFHIRTemplateGenerator {
             return false;
         }
         if (config.isEnableAggregatedApi()) {
-            Path projectPath = config.isMinimalGeneration() ? basePath : basePath.resolve("fhir-service");
+            Path projectPath = (config.isMinimalGeneration() || config.isFlatOutput())
+                    ? basePath : basePath.resolve("fhir-service");
             return Files.exists(projectPath.resolve("service.bal"));
         }
         if (serviceMap == null || serviceMap.isEmpty()) {

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/MetaGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/MetaGenerator.java
@@ -121,6 +121,7 @@ public class MetaGenerator extends AbstractFHIRTemplateGenerator {
         templateContext.setProperty("sampleIGLowerCase", sampleIG.toLowerCase());
         templateContext.setProperty("profileURLs", profileURLs);
         templateContext.setProperty("config", config);
+        templateContext.setProperty("licenseYear", BallerinaProjectConstants.LICENSE_YEAR);
         templateContext.setProperty("metaConfig", config.getMetadataConfig());
         templateContext.setProperty("service", service);
         templateContext.setProperty("apiName", generatorProperties.get("resourceType") + "API");

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/ServiceGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/ServiceGenerator.java
@@ -63,6 +63,7 @@ public class ServiceGenerator extends AbstractFHIRTemplateGenerator {
         TemplateContext templateContext = this.getNewTemplateContext();
         BallerinaService ballerinaService = initializeServiceWithDefaults(generatorProperties);
         templateContext.setProperty("service", ballerinaService);
+        templateContext.setProperty("licenseYear", BallerinaProjectConstants.LICENSE_YEAR);
         templateContext.setProperty("basePackageImportIdentifier", generatorProperties.get("basePackageImportIdentifier"));
         templateContext.setProperty("servicePackageImportIdentifier", generatorProperties.get("servicePackageImportIdentifier"));
         templateContext.setProperty("dependentPackageImportIdentifier", generatorProperties.get("dependentPackageImportIdentifier"));

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/ServiceGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/ServiceGenerator.java
@@ -25,6 +25,7 @@ import org.wso2.healthcare.codegen.tool.framework.fhir.core.AbstractFHIRTemplate
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.BallerinaProjectConstants;
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.config.BallerinaProjectToolConfig;
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.BallerinaService;
+import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model.FHIRProfile;
 
 import java.io.File;
 import java.util.HashMap;
@@ -54,7 +55,25 @@ public class ServiceGenerator extends AbstractFHIRTemplateGenerator {
         HashMap<String, String> dependencies = (HashMap<String, String>) generatorProperties.get("dependencies");
         ballerinaService.addImport(dependencies.get("basePackage"));
         ballerinaService.addImport(dependencies.get("servicePackage"));
-        ballerinaService.addImport(dependencies.get("dependentPackage"));
+        if (ballerinaProjectToolConfig.getIncludedIGConfigs().size() <= 1) {
+            // Multi-IG: every profile already resolves to its own package via the loop below: nothing in the
+            // generated service references the tool-wide default, so importing it here would be an unused
+            // import (a Ballerina compile error, not just a warning).
+            ballerinaService.addImport(dependencies.get("dependentPackage"));
+        }
+        // Only multi-IG needs per-profile imports (each IG keeps its own real name/importStatement -- see
+        // AbstractBallerinaProjectTool.populateIGs()). For a single IncludedIGConfig entry,
+        // profile.getImportsList() is unreliable regardless of embed vs. explicit dependent package:
+        // populateIGs() rewrites that IG's importStatement to <project org>/<versionConfig namePrefix>, which
+        // is a different string (different org, or a local-module path) than the correct, already-added
+        // dependencies.get("dependentPackage") -- adding it too causes a duplicate/conflicting import.
+        if (ballerinaProjectToolConfig.getIncludedIGConfigs().size() > 1) {
+            for (FHIRProfile profile : ballerinaService.getProfileList()) {
+                for (Object importStatement : profile.getImportsList()) {
+                    ballerinaService.addImport((String) importStatement);
+                }
+            }
+        }
         ballerinaService.setOperationConfigs(ballerinaProjectToolConfig.getOperationConfig());
         return ballerinaService;
     }

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/TomlGenerator.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/generator/TomlGenerator.java
@@ -57,7 +57,7 @@ public class TomlGenerator extends AbstractFHIRTemplateGenerator {
             templateContext.setProperty("templateName", config.getVersionConfig().getNamePrefix() + "." +
                     generatorProperties.get("resourceType").toString().toLowerCase());
         } else {
-            templateContext.setProperty("templateName", "FHIRServerTemplate");
+            templateContext.setProperty("templateName", config.getTemplatePackageName());
         }
         templateContext.setProperty("keywords", this.generateKeywords(config,
                 (BallerinaService) generatorProperties.get("service")));

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/model/BallerinaService.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/model/BallerinaService.java
@@ -126,4 +126,13 @@ public class BallerinaService {
     public void addFhirProfile(FHIRProfile profile){
         profileList.add(profile);
     }
+
+    /**
+     * True when this resource type is backed by more than one profile (e.g. Plan-Net's Organization and
+     * Network both profile the FHIR Organization resource type). Search generation dispatches on
+     * {@code _profile} in this case; a single profile keeps the plain, non-dispatching search skeleton.
+     */
+    public boolean hasMultipleProfiles() {
+        return profileList.size() > 1;
+    }
 }

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/model/FHIRProfile.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/model/FHIRProfile.java
@@ -120,6 +120,11 @@ public class FHIRProfile<StructureDefinition> {
     }
 
     public void setPackagePrefix(BallerinaProjectToolConfig config) {
+        if (config.isGenerateIgModuleEnabled() && config.getGenerateIgModuleName() != null
+                && !config.getGenerateIgModuleName().isEmpty()) {
+            this.packagePrefix = config.getGenerateIgModuleName();
+            return;
+        }
         String igPackage = config.getVersionConfig().getDependentPackage();
         if (igPackage.contains("/")) {
             String pkgNameWithoutOrg = igPackage.split("/")[1];

--- a/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/model/FHIRProfile.java
+++ b/native/fhir-to-bal-template/src/main/java/org/wso2/healthcare/fhir/codegen/ballerina/project/tool/model/FHIRProfile.java
@@ -21,6 +21,7 @@ package org.wso2.healthcare.fhir.codegen.ballerina.project.tool.model;
 import com.google.gson.JsonObject;
 import org.apache.commons.text.CaseUtils;
 import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.config.BallerinaProjectToolConfig;
+import org.wso2.healthcare.fhir.codegen.ballerina.project.tool.config.IncludedIGConfig;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -125,7 +126,12 @@ public class FHIRProfile<StructureDefinition> {
             this.packagePrefix = config.getGenerateIgModuleName();
             return;
         }
-        String igPackage = config.getVersionConfig().getDependentPackage();
+        // Prefer this profile's own IG's resolved package over the single tool-wide default: in a multi-IG run
+        // each IG maps to a different package, so falling back to the shared versionConfig value here would
+        // give every profile the same (wrong, for all but one IG) package prefix.
+        IncludedIGConfig igConfig = config.getIncludedIGConfigs().get(this.getIgName());
+        String igPackage = (igConfig != null && igConfig.getImportStatement() != null)
+                ? igConfig.getImportStatement() : config.getVersionConfig().getDependentPackage();
         if (igPackage.contains("/")) {
             String pkgNameWithoutOrg = igPackage.split("/")[1];
             this.packagePrefix = pkgNameWithoutOrg.substring(pkgNameWithoutOrg.lastIndexOf(".") + 1);

--- a/native/fhir-to-bal-template/src/main/resources/template/aggregatedBalService.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/aggregatedBalService.vm
@@ -1,5 +1,5 @@
 #set($sqBrackets=[])
-// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+// Copyright (c) ${licenseYear}, WSO2 LLC. (http://www.wso2.com).
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/native/fhir-to-bal-template/src/main/resources/template/aggregatedBalService.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/aggregatedBalService.vm
@@ -41,8 +41,17 @@ public type $resourceType #**##foreach($profile in $service.getProfileList())$pr
 
 // ######################################################################################################################
 // # $resourceType API                                                                                                          #
-// ###################################################################################################################### 
+// ######################################################################################################################
 
+#if($service.hasMultipleProfiles())
+// $resourceType is profiled by more than one implementation guide. Fill in each profile's search below.
+#foreach($profile in $service.getProfileList())
+isolated function search$profile.getName()($basePackageImportIdentifier:FHIRContext fhirContext) returns $basePackageImportIdentifier:Bundle|$basePackageImportIdentifier:OperationOutcome|$basePackageImportIdentifier:FHIRError {
+    return $basePackageImportIdentifier:createFHIRError("Not implemented", $basePackageImportIdentifier:ERROR, $basePackageImportIdentifier:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+}
+
+#end
+#end
 service /fhir/$service.getFhirVersion()/$resourceType on new $servicePackageImportIdentifier:Listener(config = ${resourceType.toLowerCase()}ApiConfig) {
 
     // Read the current state of single resource based on its id.
@@ -55,10 +64,30 @@ service /fhir/$service.getFhirVersion()/$resourceType on new $servicePackageImpo
         return $basePackageImportIdentifier:createFHIRError("Not implemented", $basePackageImportIdentifier:ERROR, $basePackageImportIdentifier:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
     }
 
+#if($service.hasMultipleProfiles())
+    // Search for resources based on a set of criteria. Dispatches by _profile since $resourceType has
+    // more than one profile; add a default here if unspecified _profile should resolve to one of them.
+    isolated resource function get .($basePackageImportIdentifier:FHIRContext fhirContext) returns $basePackageImportIdentifier:Bundle|$basePackageImportIdentifier:OperationOutcome|$basePackageImportIdentifier:FHIRError {
+        readonly & $basePackageImportIdentifier:RequestSearchParameter[]? _profileParams = fhirContext.getRequestSearchParameter("_profile");
+        string? _profile = _profileParams is $basePackageImportIdentifier:RequestSearchParameter[] && _profileParams.length() > 0
+                ? _profileParams[0].value : ();
+        match _profile {
+#foreach($profile in $service.getProfileList())
+            "$profile.getUrl()" => {
+                return search$profile.getName()(fhirContext);
+            }
+#end
+            _ => {
+                return $basePackageImportIdentifier:createFHIRError("Not implemented", $basePackageImportIdentifier:ERROR, $basePackageImportIdentifier:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+            }
+        }
+    }
+#else
     // Search for resources based on a set of criteria.
     isolated resource function get .($basePackageImportIdentifier:FHIRContext fhirContext) returns $basePackageImportIdentifier:Bundle|$basePackageImportIdentifier:OperationOutcome|$basePackageImportIdentifier:FHIRError {
         return $basePackageImportIdentifier:createFHIRError("Not implemented", $basePackageImportIdentifier:ERROR, $basePackageImportIdentifier:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
     }
+#end
 
     // Create a new resource.
     isolated resource function post .($basePackageImportIdentifier:FHIRContext fhirContext, $resourceType $resourceType.toLowerCase()) returns $resourceType|$basePackageImportIdentifier:OperationOutcome|$basePackageImportIdentifier:FHIRError {

--- a/native/fhir-to-bal-template/src/main/resources/template/aggregatedBalService.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/aggregatedBalService.vm
@@ -22,7 +22,7 @@
 
 import ballerina/http;
 #foreach($import in $aggregatedService.getImportsList())
-import $import.toLowerCase();
+import $import;
 #end
 
 # Generic types to wrap all implemented profiles for each resource.

--- a/native/fhir-to-bal-template/src/main/resources/template/apiConfig.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/apiConfig.vm
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+// Copyright (c) ${licenseYear}, WSO2 LLC. (http://www.wso2.com).
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/native/fhir-to-bal-template/src/main/resources/template/balService.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/balService.vm
@@ -1,5 +1,5 @@
 #set($sqBrackets=[])
-// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+// Copyright (c) ${licenseYear}, WSO2 LLC. (http://www.wso2.com).
 
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/native/fhir-to-bal-template/src/main/resources/template/balService.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/balService.vm
@@ -22,7 +22,7 @@
 
 import ballerina/http;
 #foreach($import in $service.getImportsList())
-import $import.toLowerCase();
+import $import;
 #end
 
 # Generic type to wrap all implemented profiles.

--- a/native/fhir-to-bal-template/src/main/resources/template/balService.vm
+++ b/native/fhir-to-bal-template/src/main/resources/template/balService.vm
@@ -32,6 +32,15 @@ public type $service.getName() #**##foreach($profile in $service.getProfileList(
 
 # initialize source system endpoint here
 
+#if($service.hasMultipleProfiles())
+// $service.getName() is profiled by more than one implementation guide. Fill in each profile's search below.
+#foreach($profile in $service.getProfileList())
+isolated function search$profile.getName()($basePackageImportIdentifier:FHIRContext fhirContext) returns $basePackageImportIdentifier:Bundle|$basePackageImportIdentifier:OperationOutcome|$basePackageImportIdentifier:FHIRError {
+    return $basePackageImportIdentifier:createFHIRError("Not implemented", $basePackageImportIdentifier:ERROR, $basePackageImportIdentifier:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+}
+
+#end
+#end
 # A service representing a network-accessible API
 # bound to port `9090`.
 service / on new $servicePackageImportIdentifier:Listener(9090, apiConfig) {
@@ -46,10 +55,30 @@ service / on new $servicePackageImportIdentifier:Listener(9090, apiConfig) {
         return $basePackageImportIdentifier:createFHIRError("Not implemented", $basePackageImportIdentifier:ERROR, $basePackageImportIdentifier:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
     }
 
+#if($service.hasMultipleProfiles())
+    // Search for resources based on a set of criteria. Dispatches by _profile since $service.getName() has
+    // more than one profile; add a default here if unspecified _profile should resolve to one of them.
+    isolated resource function get fhir/$service.getFhirVersion()/$service.getName() ($basePackageImportIdentifier:FHIRContext fhirContext) returns $basePackageImportIdentifier:Bundle|$basePackageImportIdentifier:OperationOutcome|$basePackageImportIdentifier:FHIRError {
+        readonly & $basePackageImportIdentifier:RequestSearchParameter[]? _profileParams = fhirContext.getRequestSearchParameter("_profile");
+        string? _profile = _profileParams is $basePackageImportIdentifier:RequestSearchParameter[] && _profileParams.length() > 0
+                ? _profileParams[0].value : ();
+        match _profile {
+#foreach($profile in $service.getProfileList())
+            "$profile.getUrl()" => {
+                return search$profile.getName()(fhirContext);
+            }
+#end
+            _ => {
+                return $basePackageImportIdentifier:createFHIRError("Not implemented", $basePackageImportIdentifier:ERROR, $basePackageImportIdentifier:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
+            }
+        }
+    }
+#else
     // Search for resources based on a set of criteria.
     isolated resource function get fhir/$service.getFhirVersion()/$service.getName() ($basePackageImportIdentifier:FHIRContext fhirContext) returns $basePackageImportIdentifier:Bundle|$basePackageImportIdentifier:OperationOutcome|$basePackageImportIdentifier:FHIRError {
         return $basePackageImportIdentifier:createFHIRError("Not implemented", $basePackageImportIdentifier:ERROR, $basePackageImportIdentifier:INFORMATIONAL, httpStatusCode = http:STATUS_NOT_IMPLEMENTED);
     }
+#end
 
     // Create a new resource.
     isolated resource function post fhir/$service.getFhirVersion()/$service.getName() ($basePackageImportIdentifier:FHIRContext fhirContext, $service.getName() procedure) returns $service.getName()|$basePackageImportIdentifier:OperationOutcome|$basePackageImportIdentifier:FHIRError {

--- a/native/health-cli/pom.xml
+++ b/native/health-cli/pom.xml
@@ -25,11 +25,11 @@
     <parent>
         <groupId>io.ballerina</groupId>
         <artifactId>health-tools</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>health-cli</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <dependencies>
         <dependency>
@@ -52,6 +52,11 @@
             <groupId>org.wso2.healthcare.codegen.tool.framework</groupId>
             <artifactId>fhir-core</artifactId>
             <version>${version.healthcare.tool.framework}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.ballerina</groupId>
+            <artifactId>fhir-to-bal-lib</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
@@ -77,6 +82,17 @@
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${version.json.schema.validator}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.26.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -122,6 +138,16 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                     </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*Runner.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -316,6 +342,17 @@
                                         <argument>test</argument>
                                         <argument>target/test-classes/health.fhir.r5.europebase/</argument>
                                     </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>run-local-module-template-test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <configuration>
+                                    <mainClass>LocalModuleTemplateTestRunner</mainClass>
+                                    <classpathScope>test</classpathScope>
                                 </configuration>
                             </execution>
                         </executions>

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/config/IgRegistryConfig.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/config/IgRegistryConfig.java
@@ -131,8 +131,16 @@ public class IgRegistryConfig {
         return defaultPackages.getOrDefault(fhirVersion.toLowerCase(), defaultPackages.get("r4"));
     }
 
-    public String resolveDependentPackage(String igName) {
-        return packageMappings.get(igName);
+    /**
+     * Looks up a known published Ballerina package for an exact {@code <igName>@<igVersion>} match. Keyed by the
+     * full pair (not just the IG name) since a mapped package targets one specific IG version -- the package's
+     * own version-ish naming (e.g. "carinbb200") does not reliably indicate which IG version it was built from.
+     */
+    public String resolveDependentPackage(String igName, String igVersion) {
+        if (igName == null || igVersion == null) {
+            return null;
+        }
+        return packageMappings.get(igName + "@" + igVersion);
     }
 
     public record IgPackageRef(String name, String version) {

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/config/IgRegistryConfig.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/config/IgRegistryConfig.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.config;
+
+import com.google.gson.JsonObject;
+import io.ballerina.health.cmd.core.utils.HealthCmdConstants;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration for FHIR IG package registry download ({@code fhir.igRegistry} in tool-config.json).
+ */
+public class IgRegistryConfig {
+
+    private final String registryUrl;
+    private final String cacheDir;
+    private final int httpTimeoutSeconds;
+    private final Map<String, IgPackageRef> defaultPackages;
+    private final Map<String, String> packageMappings;
+
+    public IgRegistryConfig(String registryUrl, String cacheDir, int httpTimeoutSeconds,
+                            Map<String, IgPackageRef> defaultPackages, Map<String, String> packageMappings) {
+        this.registryUrl = registryUrl;
+        this.cacheDir = cacheDir;
+        this.httpTimeoutSeconds = httpTimeoutSeconds;
+        this.defaultPackages = defaultPackages != null ? defaultPackages : Collections.emptyMap();
+        this.packageMappings = packageMappings != null ? packageMappings : Collections.emptyMap();
+    }
+
+    public static IgRegistryConfig fromFhirConfig(JsonObject fhirConfig) {
+        if (fhirConfig == null || !fhirConfig.has("igRegistry")) {
+            return defaults();
+        }
+        JsonObject igRegistry = fhirConfig.getAsJsonObject("igRegistry");
+        String registryUrl = getString(igRegistry, "registryUrl", HealthCmdConstants.CMD_DEFAULT_REGISTRY_URL);
+        String cacheDir = getString(igRegistry, "cacheDir", HealthCmdConstants.CMD_DEFAULT_IG_CACHE_DIR);
+        int timeout = igRegistry.has("httpTimeoutSeconds")
+                ? igRegistry.get("httpTimeoutSeconds").getAsInt()
+                : HealthCmdConstants.CMD_DEFAULT_IG_HTTP_TIMEOUT_SECONDS;
+
+        Map<String, IgPackageRef> defaultPackages = new HashMap<>();
+        if (igRegistry.has("defaultPackages")) {
+            JsonObject defaults = igRegistry.getAsJsonObject("defaultPackages");
+            for (String fhirVersion : defaults.keySet()) {
+                JsonObject pkg = defaults.getAsJsonObject(fhirVersion);
+                defaultPackages.put(fhirVersion, new IgPackageRef(
+                        pkg.get("name").getAsString(),
+                        pkg.get("version").getAsString()
+                ));
+            }
+        }
+        if (defaultPackages.isEmpty()) {
+            defaultPackages.put("r4", new IgPackageRef(
+                    HealthCmdConstants.CMD_DEFAULT_R4_IG_PACKAGE_NAME,
+                    HealthCmdConstants.CMD_DEFAULT_R4_IG_PACKAGE_VERSION));
+            defaultPackages.put("r5", new IgPackageRef(
+                    HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_NAME,
+                    HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_VERSION));
+        }
+
+        Map<String, String> mappings = new HashMap<>();
+        if (igRegistry.has("packageMappings")) {
+            JsonObject mappingObj = igRegistry.getAsJsonObject("packageMappings");
+            for (String key : mappingObj.keySet()) {
+                mappings.put(key, mappingObj.get(key).getAsString());
+            }
+        }
+
+        return new IgRegistryConfig(registryUrl, cacheDir, timeout, defaultPackages, mappings);
+    }
+
+    public static IgRegistryConfig defaults() {
+        Map<String, IgPackageRef> defaultPackages = Map.of(
+                "r4", new IgPackageRef(
+                        HealthCmdConstants.CMD_DEFAULT_R4_IG_PACKAGE_NAME,
+                        HealthCmdConstants.CMD_DEFAULT_R4_IG_PACKAGE_VERSION),
+                "r5", new IgPackageRef(
+                        HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_NAME,
+                        HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_VERSION)
+        );
+        return new IgRegistryConfig(
+                HealthCmdConstants.CMD_DEFAULT_REGISTRY_URL,
+                HealthCmdConstants.CMD_DEFAULT_IG_CACHE_DIR,
+                HealthCmdConstants.CMD_DEFAULT_IG_HTTP_TIMEOUT_SECONDS,
+                defaultPackages,
+                Collections.emptyMap()
+        );
+    }
+
+    private static String getString(JsonObject obj, String key, String defaultValue) {
+        if (obj.has(key) && !obj.get(key).getAsString().isEmpty()) {
+            return obj.get(key).getAsString();
+        }
+        return defaultValue;
+    }
+
+    public String getRegistryUrl() {
+        return registryUrl;
+    }
+
+    public String getCacheDir() {
+        return cacheDir;
+    }
+
+    public int getHttpTimeoutSeconds() {
+        return httpTimeoutSeconds;
+    }
+
+    public IgPackageRef getDefaultPackage(String fhirVersion) {
+        if (fhirVersion == null) {
+            return defaultPackages.get("r4");
+        }
+        return defaultPackages.getOrDefault(fhirVersion.toLowerCase(), defaultPackages.get("r4"));
+    }
+
+    public String resolveDependentPackage(String igName) {
+        return packageMappings.get(igName);
+    }
+
+    public record IgPackageRef(String name, String version) {
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloader.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloader.java
@@ -64,6 +64,34 @@ public final class FhirIgPackageDownloader {
         return new ParsedIgSpec(name, version);
     }
 
+    /**
+     * Parses an npm-style IG reference ({@code <name>[@version]}, e.g. {@code hl7.fhir.us.core@8.0.1}) as accepted
+     * by the {@code --ig} option. A missing version resolves to {@code latest}.
+     */
+    public static ParsedIgSpec parseIgReference(String igReference) {
+        if (igReference == null || igReference.trim().isEmpty()) {
+            throw new IllegalArgumentException("IG reference cannot be empty");
+        }
+        String trimmed = igReference.trim();
+        int at = trimmed.lastIndexOf('@');
+        String name = at >= 0 ? trimmed.substring(0, at) : trimmed;
+        String version = at >= 0 ? trimmed.substring(at + 1) : null;
+        return parseIgSpec(name, version);
+    }
+
+    /**
+     * Returns {@code true} when {@code igReference} has a non-empty name component before the last {@code @}.
+     */
+    public static boolean isValidIgReference(String igReference) {
+        if (igReference == null || igReference.trim().isEmpty()) {
+            return false;
+        }
+        String trimmed = igReference.trim();
+        int at = trimmed.lastIndexOf('@');
+        String name = at >= 0 ? trimmed.substring(0, at) : trimmed;
+        return !name.trim().isEmpty();
+    }
+
     public static String fetchPackageMetadata(String registryUrl, String packageName, int timeoutSeconds)
             throws BallerinaHealthException {
         String registryBase = registryUrl.replaceAll("/+$", "");
@@ -202,6 +230,12 @@ public final class FhirIgPackageDownloader {
             }
         }
 
+        PrintStream out = options.printStream() != null ? options.printStream() : System.out;
+        if (options.cacheDirExplicit() && cachePath != null) {
+            out.println(HealthCmdConstants.PrintStrings.IG_CACHE_MISS_WARNING + cachePath
+                    + ". Downloading from the registry instead.");
+        }
+
         String registryUrl = options.registryUrl().replaceAll("/+$", "");
         String url = registryUrl + "/" + spec.name() + "/" + spec.version();
         byte[] data = httpGet(url, options.httpTimeoutSeconds());
@@ -210,6 +244,10 @@ public final class FhirIgPackageDownloader {
             try {
                 Files.createDirectories(cachePath.getParent());
                 Files.write(cachePath, data);
+                if (options.cacheDirRelativeToProject()) {
+                    out.println(HealthCmdConstants.PrintStrings.IG_CACHE_GITIGNORE_WARNING
+                            + options.cacheDir() + "/");
+                }
             } catch (IOException ignored) {
                 // best-effort cache write
             }
@@ -296,10 +334,12 @@ public final class FhirIgPackageDownloader {
             int httpTimeoutSeconds,
             boolean forceDownload,
             boolean nonInteractive,
+            boolean cacheDirExplicit,
+            boolean cacheDirRelativeToProject,
             PrintStream printStream
     ) {
         public DownloadOptions(String registryUrl, String cacheDir, int httpTimeoutSeconds, boolean forceDownload) {
-            this(registryUrl, cacheDir, httpTimeoutSeconds, forceDownload, false, System.out);
+            this(registryUrl, cacheDir, httpTimeoutSeconds, forceDownload, false, false, true, System.out);
         }
     }
 }

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloader.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloader.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.zip.GZIPInputStream;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+
+/**
+ * Downloads FHIR IG packages from the FHIR package registry and extracts JSON resources for codegen.
+ * Mirrors the fetch/extract flow in fhir-server-go {@code internal/ig}.
+ */
+public final class FhirIgPackageDownloader {
+
+    private static final String PACKAGE_PREFIX = "package/";
+    private static final String VERSION_LATEST_TAG = "latest";
+
+    private FhirIgPackageDownloader() {
+    }
+
+    public static ParsedIgSpec parseIgSpec(String igName, String igVersion) {
+        if (igName == null || igName.trim().isEmpty()) {
+            throw new IllegalArgumentException("IG package name cannot be empty");
+        }
+        String name = igName.trim();
+        String version = (igVersion == null || igVersion.trim().isEmpty())
+                ? VERSION_LATEST_TAG : igVersion.trim();
+        return new ParsedIgSpec(name, version);
+    }
+
+    public static String fetchPackageMetadata(String registryUrl, String packageName, int timeoutSeconds)
+            throws BallerinaHealthException {
+        String registryBase = registryUrl.replaceAll("/+$", "");
+        String metadataUrl = registryBase + "/" + packageName;
+        byte[] metadataBody = httpGet(metadataUrl, timeoutSeconds);
+        return new String(metadataBody, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Resolves the package version to download. When version is omitted or {@code latest}, fetches registry
+     * metadata and either prompts for a version (interactive) or uses {@code dist-tags.latest} (non-interactive).
+     */
+    public static String resolvePackageVersion(String registryUrl, String packageName, String requestedVersion,
+                                               DownloadOptions options) throws BallerinaHealthException {
+        if (!needsVersionResolution(requestedVersion)) {
+            return requestedVersion.trim();
+        }
+        String metadataJson = fetchPackageMetadata(registryUrl, packageName, options.httpTimeoutSeconds());
+        String latestTag = parseLatestVersionFromMetadata(metadataJson, packageName);
+        List<String> availableVersions = IgVersionSelector.parseAvailableVersions(metadataJson);
+        return IgVersionSelector.selectVersion(
+                packageName,
+                availableVersions,
+                latestTag,
+                options.nonInteractive(),
+                options.printStream());
+    }
+
+    /**
+     * Parses {@code dist-tags.latest} from FHIR package registry metadata JSON.
+     */
+    public static String parseLatestVersionFromMetadata(String metadataJson, String packageName)
+            throws BallerinaHealthException {
+        try {
+            JsonObject root = JsonParser.parseString(metadataJson).getAsJsonObject();
+            if (!root.has("dist-tags") || !root.get("dist-tags").isJsonObject()) {
+                throw new BallerinaHealthException("Package metadata for " + packageName
+                        + " does not contain dist-tags.");
+            }
+            JsonObject distTags = root.getAsJsonObject("dist-tags");
+            if (!distTags.has(VERSION_LATEST_TAG)
+                    || distTags.get(VERSION_LATEST_TAG).getAsString().trim().isEmpty()) {
+                throw new BallerinaHealthException("Package metadata for " + packageName
+                        + " does not contain dist-tags.latest.");
+            }
+            return distTags.get(VERSION_LATEST_TAG).getAsString().trim();
+        } catch (BallerinaHealthException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BallerinaHealthException("Failed to parse package metadata for " + packageName + ": "
+                    + e.getMessage(), e);
+        }
+    }
+
+    public static ParsedIgSpec resolveIgSpec(String igName, String igVersion, DownloadOptions options)
+            throws BallerinaHealthException {
+        ParsedIgSpec spec = parseIgSpec(igName, igVersion);
+        String resolvedVersion = resolvePackageVersion(options.registryUrl(), spec.name(), spec.version(), options);
+        return new ParsedIgSpec(spec.name(), resolvedVersion);
+    }
+
+    private static boolean needsVersionResolution(String requestedVersion) {
+        return requestedVersion == null || requestedVersion.trim().isEmpty()
+                || VERSION_LATEST_TAG.equalsIgnoreCase(requestedVersion.trim());
+    }
+
+    /**
+     * Downloads (or reads from cache) and extracts the IG package into {@code targetDirectory}.
+     */
+    public static Path downloadAndExtract(Path targetDirectory, String packageName, String packageVersion,
+                                         DownloadOptions options) throws BallerinaHealthException {
+        return downloadAndExtract(targetDirectory, resolveIgSpec(packageName, packageVersion, options), options);
+    }
+
+    /**
+     * Downloads (or reads from cache) and extracts the IG package into {@code targetDirectory}.
+     */
+    public static Path downloadAndExtract(Path targetDirectory, ParsedIgSpec spec, DownloadOptions options)
+            throws BallerinaHealthException {
+        if (!options.forceDownload()
+                && SpecificationPathUtils.containsStructureDefinitionResources(targetDirectory)) {
+            return targetDirectory;
+        }
+
+        try {
+            if (options.forceDownload() && Files.exists(targetDirectory)) {
+                deleteDirectoryContents(targetDirectory);
+            }
+            Files.createDirectories(targetDirectory);
+        } catch (IOException e) {
+            throw new BallerinaHealthException("Failed to prepare IG extract directory: " + targetDirectory, e);
+        }
+
+        byte[] tgzData = fetchPackageBytes(spec, options);
+        extractPackage(tgzData, targetDirectory);
+
+        if (!SpecificationPathUtils.containsStructureDefinitionResources(targetDirectory)) {
+            throw new BallerinaHealthException("Downloaded IG package did not contain any StructureDefinition "
+                    + "resources under " + targetDirectory);
+        }
+        return targetDirectory;
+    }
+
+    /**
+     * Extracts a FHIR package tarball into {@code targetDirectory} (for tests and local .tgz use).
+     */
+    public static void extractPackage(byte[] tgzData, Path targetDirectory) throws BallerinaHealthException {
+        try (InputStream gzipIn = new GZIPInputStream(new ByteArrayInputStream(tgzData));
+             TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn)) {
+            ArchiveEntry entry;
+            while ((entry = tarIn.getNextEntry()) != null) {
+                if (!entry.getName().startsWith(PACKAGE_PREFIX) || entry.isDirectory()) {
+                    continue;
+                }
+                String relative = entry.getName().substring(PACKAGE_PREFIX.length());
+                if (!relative.endsWith(".json")) {
+                    continue;
+                }
+                Path destination = targetDirectory.resolve(relative);
+                Files.createDirectories(destination.getParent());
+                writeEntry(tarIn, destination);
+            }
+        } catch (IOException e) {
+            throw new BallerinaHealthException("Failed to extract IG package: " + e.getMessage(), e);
+        }
+    }
+
+    private static byte[] fetchPackageBytes(ParsedIgSpec spec, DownloadOptions options)
+            throws BallerinaHealthException {
+        Path cachePath = resolveCachePath(options.cacheDir(), spec.name(), spec.version());
+        if (cachePath != null && Files.exists(cachePath) && !options.forceDownload()) {
+            try {
+                return Files.readAllBytes(cachePath);
+            } catch (IOException e) {
+                throw new BallerinaHealthException("Failed to read cached IG package: " + cachePath, e);
+            }
+        }
+
+        String registryUrl = options.registryUrl().replaceAll("/+$", "");
+        String url = registryUrl + "/" + spec.name() + "/" + spec.version();
+        byte[] data = httpGet(url, options.httpTimeoutSeconds());
+
+        if (cachePath != null) {
+            try {
+                Files.createDirectories(cachePath.getParent());
+                Files.write(cachePath, data);
+            } catch (IOException ignored) {
+                // best-effort cache write
+            }
+        }
+        return data;
+    }
+
+    static byte[] httpGet(String url, int timeoutSeconds) throws BallerinaHealthException {
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(timeoutSeconds))
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(timeoutSeconds))
+                    .GET()
+                    .build();
+            HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() != 200) {
+                throw new BallerinaHealthException("Failed to download IG package from " + url
+                        + " (HTTP " + response.statusCode() + ")");
+            }
+            return response.body();
+        } catch (BallerinaHealthException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BallerinaHealthException("Failed to download IG package from " + url + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static Path resolveCachePath(String cacheDir, String name, String version) {
+        if (cacheDir == null || cacheDir.isEmpty()) {
+            return null;
+        }
+        String safeName = name.replace('/', '_').replace('\\', '_');
+        return Path.of(cacheDir).resolve(safeName + "-" + version + ".tgz");
+    }
+
+    private static void writeEntry(TarArchiveInputStream tarIn, Path destination) throws IOException {
+        try (OutputStream out = Files.newOutputStream(destination)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = tarIn.read(buffer)) >= 0) {
+                out.write(buffer, 0, read);
+            }
+        }
+    }
+
+    private static void deleteDirectoryContents(Path directory) throws BallerinaHealthException {
+        try (var paths = Files.walk(directory)) {
+            paths.sorted((a, b) -> b.compareTo(a))
+                    .filter(path -> !path.equals(directory))
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof IOException io) {
+                throw new BallerinaHealthException("Failed to clear directory " + directory, io);
+            }
+            throw e;
+        } catch (IOException e) {
+            throw new BallerinaHealthException("Failed to clear directory " + directory, e);
+        }
+    }
+
+    public static String sanitizeIgDirectoryName(String igName) {
+        return igName.replace('.', '_').replace('/', '_').toLowerCase(Locale.ROOT);
+    }
+
+    public record ParsedIgSpec(String name, String version) {
+        public String source() {
+            return name + "@" + version;
+        }
+    }
+
+    public record DownloadOptions(
+            String registryUrl,
+            String cacheDir,
+            int httpTimeoutSeconds,
+            boolean forceDownload,
+            boolean nonInteractive,
+            PrintStream printStream
+    ) {
+        public DownloadOptions(String registryUrl, String cacheDir, int httpTimeoutSeconds, boolean forceDownload) {
+            this(registryUrl, cacheDir, httpTimeoutSeconds, forceDownload, false, System.out);
+        }
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloader.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloader.java
@@ -153,6 +153,16 @@ public final class FhirIgPackageDownloader {
         return new ParsedIgSpec(spec.name(), resolvedVersion);
     }
 
+    /**
+     * True when {@code targetDirectory} already has an extracted IG whose {@code package.json} version differs
+     * from {@code requestedVersion}. A directory with no readable version is assumed to already match, so a
+     * plain user-supplied local spec directory (no package.json) is never treated as stale.
+     */
+    private static boolean isVersionMismatch(Path targetDirectory, String requestedVersion) {
+        String installedVersion = SpecificationPathUtils.readInstalledPackageVersion(targetDirectory);
+        return installedVersion != null && !installedVersion.equals(requestedVersion);
+    }
+
     private static boolean needsVersionResolution(String requestedVersion) {
         return requestedVersion == null || requestedVersion.trim().isEmpty()
                 || VERSION_LATEST_TAG.equalsIgnoreCase(requestedVersion.trim());
@@ -171,13 +181,20 @@ public final class FhirIgPackageDownloader {
      */
     public static Path downloadAndExtract(Path targetDirectory, ParsedIgSpec spec, DownloadOptions options)
             throws BallerinaHealthException {
-        if (!options.forceDownload()
-                && SpecificationPathUtils.containsStructureDefinitionResources(targetDirectory)) {
+        boolean alreadyPresent = SpecificationPathUtils.containsStructureDefinitionResources(targetDirectory);
+        boolean versionMismatch = alreadyPresent && isVersionMismatch(targetDirectory, spec.version());
+        if (!options.forceDownload() && alreadyPresent && !versionMismatch) {
             return targetDirectory;
         }
 
+        if (versionMismatch) {
+            PrintStream out = options.printStream() != null ? options.printStream() : System.out;
+            out.println(HealthCmdConstants.PrintStrings.IG_VERSION_MISMATCH_WARNING + targetDirectory
+                    + " — installed version doesn't match the requested " + spec.version() + ".");
+        }
+
         try {
-            if (options.forceDownload() && Files.exists(targetDirectory)) {
+            if ((options.forceDownload() || versionMismatch) && Files.exists(targetDirectory)) {
                 deleteDirectoryContents(targetDirectory);
             }
             Files.createDirectories(targetDirectory);

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
@@ -46,8 +46,7 @@ public class HealthCmdConstants {
     public static final String CMD_DEFAULT_R4_IG_PACKAGE_VERSION = "4.0.1";
     public static final String CMD_DEFAULT_R5_IG_PACKAGE_NAME = "hl7.fhir.r5.core";
     public static final String CMD_DEFAULT_R5_IG_PACKAGE_VERSION = "5.0.0";
-    public static final String CMD_OPTION_IG_NAME = "--ig-name";
-    public static final String CMD_OPTION_IG_VERSION = "--ig-version";
+    public static final String CMD_OPTION_IG = "--ig";
     public static final String CMD_OPTION_REGISTRY_URL = "--registry-url";
     public static final String CMD_OPTION_IG_CACHE_DIR = "--ig-cache-dir";
     public static final String CMD_OPTION_FORCE_IG_DOWNLOAD = "--force-ig-download";
@@ -118,17 +117,22 @@ public class HealthCmdConstants {
         public static final String PKG_NAME_REQUIRED = "[ERROR] Package name [--package-name] is required for package "
                 + "generation.";
         public static final String GEN_ERROR = "[ERROR] Error occurred while generating the Ballerina artifacts.";
-        public static final String DEPENDENT_REQUIRED = "[ERROR] --dependent-package, --ig-name, or a resolvable spec "
+        public static final String DEPENDENT_REQUIRED = "[ERROR] --dependent-package, --ig, or a resolvable spec "
                 + "path (local or registry download) is required for template generation.";
         public static final String IG_DOWNLOAD_SUCCESS = "[INFO] Downloaded IG package ";
-        public static final String SPEC_PATH_REQUIRED = "[ERROR] FHIR specification path or --ig-name is required.";
+        public static final String SPEC_PATH_REQUIRED = "[ERROR] FHIR specification path or --ig is required.";
         public static final String USING_INTERNATIONAL_BASE = "[INFO] No custom IG specified. Using international "
                 + "base FHIR structure definitions with ";
         public static final String DEPENDENT_INCORRECT = "[ERROR] Format of the dependent package is incorrect.";
+        public static final String IG_REFERENCE_INVALID = "[ERROR] Invalid --ig value. Expected <name>[@version], "
+                + "e.g. hl7.fhir.us.core@8.0.1.";
         public static final String INCLUDED_EXCLUDED_TOGETHER = "[ERROR] Both --included-profile and "
                 + "--excluded-profile cannot be used together.";
         public static final String CDS_HOOKS_VALIDATION = "[ERROR] CDS hooks validation failed!";
         public static final String INVALID_CONFIG_PATH = "[ERROR] Cannot find the configuration file provided for the input[-i] path argument.";
+        public static final String IG_CACHE_MISS_WARNING = "[WARN] Expected cached IG package not found: ";
+        public static final String IG_CACHE_GITIGNORE_WARNING = "[WARN] Add the IG cache directory to your "
+                + ".gitignore if it isn't already ignored: ";
 
     }
 

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
@@ -36,6 +36,21 @@ public class HealthCmdConstants {
     public static final String CMD_CDS_HELP_TEXT_FILENAME = "ballerina-health-cds.help";
     public static final String CMD_DEFAULT_IG_NAME = "FHIR";
     public static final String CMD_DEFAULT_ORG_NAME = "healthcare";
+    public static final String CMD_DEFAULT_R4_DEPENDENT_PACKAGE = "ballerinax/health.fhir.r4.international401";
+    public static final String CMD_DEFAULT_R5_DEPENDENT_PACKAGE = "ballerinax/health.fhir.r5.international500";
+    public static final String CMD_DEFAULT_INTERNATIONAL_IG_DIR = "international";
+    public static final String CMD_DEFAULT_REGISTRY_URL = "https://packages.fhir.org";
+    public static final String CMD_DEFAULT_IG_CACHE_DIR = ".fhir-ig-cache";
+    public static final int CMD_DEFAULT_IG_HTTP_TIMEOUT_SECONDS = 60;
+    public static final String CMD_DEFAULT_R4_IG_PACKAGE_NAME = "hl7.fhir.r4.core";
+    public static final String CMD_DEFAULT_R4_IG_PACKAGE_VERSION = "4.0.1";
+    public static final String CMD_DEFAULT_R5_IG_PACKAGE_NAME = "hl7.fhir.r5.core";
+    public static final String CMD_DEFAULT_R5_IG_PACKAGE_VERSION = "5.0.0";
+    public static final String CMD_OPTION_IG_NAME = "--ig-name";
+    public static final String CMD_OPTION_IG_VERSION = "--ig-version";
+    public static final String CMD_OPTION_REGISTRY_URL = "--registry-url";
+    public static final String CMD_OPTION_IG_CACHE_DIR = "--ig-cache-dir";
+    public static final String CMD_OPTION_FORCE_IG_DOWNLOAD = "--force-ig-download";
     public static final String CMD_FHIR_MODE_TEMPLATE = "fhir:template";
     public static final String CMD_FHIR_MODE_CLIENT = "fhir:client";
     public static final String CMD_FHIR_MODE_PACKAGE = "fhir:package";
@@ -103,8 +118,12 @@ public class HealthCmdConstants {
         public static final String PKG_NAME_REQUIRED = "[ERROR] Package name [--package-name] is required for package "
                 + "generation.";
         public static final String GEN_ERROR = "[ERROR] Error occurred while generating the Ballerina artifacts.";
-        public static final String DEPENDENT_REQUIRED = "[ERROR] Dependent package [--dependent-package] is required "
-                + "for template generation.";
+        public static final String DEPENDENT_REQUIRED = "[ERROR] --dependent-package, --ig-name, or a resolvable spec "
+                + "path (local or registry download) is required for template generation.";
+        public static final String IG_DOWNLOAD_SUCCESS = "[INFO] Downloaded IG package ";
+        public static final String SPEC_PATH_REQUIRED = "[ERROR] FHIR specification path or --ig-name is required.";
+        public static final String USING_INTERNATIONAL_BASE = "[INFO] No custom IG specified. Using international "
+                + "base FHIR structure definitions with ";
         public static final String DEPENDENT_INCORRECT = "[ERROR] Format of the dependent package is incorrect.";
         public static final String INCLUDED_EXCLUDED_TOGETHER = "[ERROR] Both --included-profile and "
                 + "--excluded-profile cannot be used together.";

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
@@ -134,6 +134,11 @@ public class HealthCmdConstants {
         public static final String IG_CACHE_GITIGNORE_WARNING = "[WARN] Add the IG cache directory to your "
                 + ".gitignore if it isn't already ignored: ";
         public static final String IG_VERSION_MISMATCH_WARNING = "[WARN] Replacing existing IG definitions at ";
+        public static final String MULTI_IG_TEMPLATE_ONLY = "[ERROR] Multiple --ig values are only supported in "
+                + "template mode (-m template).";
+        public static final String MULTI_IG_DEPENDENT_PACKAGE_CONFLICT = "[ERROR] --dependent-package cannot be "
+                + "combined with multiple --ig values; each IG's dependent package is resolved automatically via "
+                + "packageMappings.";
 
     }
 

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdConstants.java
@@ -133,6 +133,7 @@ public class HealthCmdConstants {
         public static final String IG_CACHE_MISS_WARNING = "[WARN] Expected cached IG package not found: ";
         public static final String IG_CACHE_GITIGNORE_WARNING = "[WARN] Add the IG cache directory to your "
                 + ".gitignore if it isn't already ignored: ";
+        public static final String IG_VERSION_MISMATCH_WARNING = "[WARN] Replacing existing IG definitions at ";
 
     }
 

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/HealthCmdUtils.java
@@ -81,7 +81,7 @@ public class HealthCmdUtils {
     }
 
     public static Path getSpecificationPath(String specPathParam, String executionPath) throws BallerinaHealthException {
-        if (specPathParam == null && specPathParam.isEmpty()) {
+        if (specPathParam == null || specPathParam.isEmpty()) {
             throw new BallerinaHealthException("Cannot find valid spec path pointed. Please check the path "
                     + specPathParam + " is valid.");
         }

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgModuleNameUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgModuleNameUtils.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.wso2.healthcare.fhir.ballerina.packagegen.tool.utils.GeneratorUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Utilities for deriving Ballerina module names from FHIR implementation guide identifiers.
+ */
+public final class IgModuleNameUtils {
+
+    private static final String MODULE_NAME_PATTERN = "^[a-zA-Z][a-zA-Z0-9_]*$";
+
+    private IgModuleNameUtils() {
+    }
+
+    public static boolean isValidBallerinaModuleName(String moduleName) {
+        return moduleName != null && !moduleName.isEmpty() && moduleName.matches(MODULE_NAME_PATTERN);
+    }
+
+    public static String inferIgModuleName(String specificationPath) throws IOException {
+        String igIdentifier = findImplementationGuideIdentifier(specificationPath);
+        if (igIdentifier == null || igIdentifier.isEmpty()) {
+            igIdentifier = inferIgNameFromDirectory(specificationPath);
+        }
+        return toBallerinaModuleName(igIdentifier);
+    }
+
+    public static String toBallerinaModuleName(String igIdentifier) {
+        if (igIdentifier == null || igIdentifier.trim().isEmpty()) {
+            throw new IllegalArgumentException("IG identifier cannot be empty");
+        }
+        String normalized = igIdentifier.trim().replace('.', '_');
+        normalized = GeneratorUtils.getInstance().resolveSpecialCharacters(normalized);
+        normalized = camelCaseToSnakeCase(normalized);
+        normalized = normalized.replaceAll("[^a-zA-Z0-9_]", "_").replaceAll("_+", "_");
+        if (normalized.endsWith("_")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("Unable to derive a Ballerina module name from IG identifier: "
+                    + igIdentifier);
+        }
+        if (!Character.isLetter(normalized.charAt(0))) {
+            normalized = "ig_" + normalized;
+        }
+        return normalized;
+    }
+
+    private static String camelCaseToSnakeCase(String value) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (Character.isUpperCase(current) && i > 0 && builder.charAt(builder.length() - 1) != '_') {
+                builder.append('_');
+            }
+            builder.append(Character.toLowerCase(current));
+        }
+        return builder.toString();
+    }
+
+    private static String findImplementationGuideIdentifier(String specificationPath) throws IOException {
+        try (Stream<Path> paths = Files.walk(Paths.get(specificationPath))) {
+            List<Path> implementationGuideFiles = paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".json"))
+                    .filter(path -> path.getFileName().toString().startsWith("ImplementationGuide")
+                            || path.getFileName().toString().contains("ImplementationGuide"))
+                    .toList();
+
+            for (Path path : implementationGuideFiles) {
+                try {
+                    JsonObject json = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+                    if (!json.has("resourceType")
+                            || !"ImplementationGuide".equals(json.get("resourceType").getAsString())) {
+                        continue;
+                    }
+                    if (json.has("name") && !json.get("name").getAsString().isEmpty()) {
+                        return json.get("name").getAsString();
+                    }
+                    if (json.has("packageId") && !json.get("packageId").getAsString().isEmpty()) {
+                        return json.get("packageId").getAsString();
+                    }
+                    if (json.has("id") && !json.get("id").getAsString().isEmpty()) {
+                        return json.get("id").getAsString();
+                    }
+                } catch (Exception ignored) {
+                    // try next candidate file
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String inferIgNameFromDirectory(String specificationPath) {
+        Path specPath = Paths.get(specificationPath);
+        String directoryName = specPath.getFileName().toString();
+        int separatorIndex = directoryName.lastIndexOf('.');
+        if (separatorIndex >= 0 && separatorIndex < directoryName.length() - 1) {
+            return directoryName.substring(separatorIndex + 1);
+        }
+        return directoryName;
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgRegistryConfigLoader.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgRegistryConfigLoader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import io.ballerina.health.cmd.core.config.HealthCmdConfig;
+import io.ballerina.health.cmd.core.config.IgRegistryConfig;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Loads {@link IgRegistryConfig} from the packaged tool-config.json.
+ */
+public final class IgRegistryConfigLoader {
+
+    private IgRegistryConfigLoader() {
+    }
+
+    public static IgRegistryConfig load() {
+        try (InputStream stream = IgRegistryConfigLoader.class.getClassLoader()
+                .getResourceAsStream(HealthCmdConstants.CMD_CONFIG_FILENAME)) {
+            if (stream == null) {
+                return IgRegistryConfig.defaults();
+            }
+            JsonObject config = HealthCmdConfig.getParsedConfigFromStream(stream);
+            if (config != null && config.has("fhir")) {
+                return IgRegistryConfig.fromFhirConfig(config.getAsJsonObject("fhir"));
+            }
+        } catch (BallerinaHealthException | IOException ignored) {
+            // use defaults
+        }
+        return IgRegistryConfig.defaults();
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgVersionSelector.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/IgVersionSelector.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.Console;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Parses FHIR package registry metadata and interactively selects a package version when needed.
+ */
+public final class IgVersionSelector {
+
+    private IgVersionSelector() {
+    }
+
+    /**
+     * Returns published version ids from registry metadata, sorted newest-first (approximate semver ordering).
+     */
+    public static List<String> parseAvailableVersions(String metadataJson) throws BallerinaHealthException {
+        try {
+            JsonObject root = JsonParser.parseString(metadataJson).getAsJsonObject();
+            if (!root.has("versions") || !root.get("versions").isJsonObject()) {
+                throw new BallerinaHealthException("Package metadata does not contain a versions map.");
+            }
+            Set<Map.Entry<String, com.google.gson.JsonElement>> entries =
+                    root.getAsJsonObject("versions").entrySet();
+            List<String> versions = new ArrayList<>();
+            for (Map.Entry<String, com.google.gson.JsonElement> entry : entries) {
+                versions.add(entry.getKey());
+            }
+            versions.sort(IgVersionSelector::compareVersionsDesc);
+            return versions;
+        } catch (BallerinaHealthException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BallerinaHealthException("Failed to parse available versions from package metadata: "
+                    + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Prompts the user to choose a version. When no console is available or {@code nonInteractive} is true,
+     * returns {@code latestTagVersion} without prompting.
+     */
+    public static String selectVersion(String packageName, List<String> availableVersions, String latestTagVersion,
+                                       boolean nonInteractive, PrintStream out) throws BallerinaHealthException {
+        if (availableVersions == null || availableVersions.isEmpty()) {
+            if (latestTagVersion != null && !latestTagVersion.isEmpty()) {
+                return latestTagVersion;
+            }
+            throw new BallerinaHealthException("No published versions found for package " + packageName + ".");
+        }
+
+        if (nonInteractive || !isInteractiveConsoleAvailable()) {
+            if (latestTagVersion != null && availableVersions.contains(latestTagVersion)) {
+                return latestTagVersion;
+            }
+            return availableVersions.get(0);
+        }
+
+        PrintStream output = out != null ? out : System.out;
+        int defaultIndex = resolveDefaultIndex(availableVersions, latestTagVersion);
+        output.println("[INFO] Available versions for " + packageName + ":");
+        for (int i = 0; i < availableVersions.size(); i++) {
+            String suffix = (i == defaultIndex) ? " (default)" : "";
+            output.printf("  [%d] %s%s%n", i + 1, availableVersions.get(i), suffix);
+        }
+
+        Console console = System.console();
+        while (true) {
+            String prompt = "Select version [1-" + availableVersions.size() + "] (default "
+                    + (defaultIndex + 1) + "): ";
+            String input = console.readLine(prompt);
+            if (input == null || input.trim().isEmpty()) {
+                return availableVersions.get(defaultIndex);
+            }
+            String trimmed = input.trim();
+            if (trimmed.matches("\\d+")) {
+                int choice = Integer.parseInt(trimmed);
+                if (choice >= 1 && choice <= availableVersions.size()) {
+                    return availableVersions.get(choice - 1);
+                }
+                output.println("[ERROR] Invalid selection. Enter a number between 1 and "
+                        + availableVersions.size() + ".");
+                continue;
+            }
+            if (availableVersions.contains(trimmed)) {
+                return trimmed;
+            }
+            output.println("[ERROR] Unknown version '" + trimmed + "'. Choose from the list above.");
+        }
+    }
+
+    static boolean isInteractiveConsoleAvailable() {
+        return System.console() != null;
+    }
+
+    private static int resolveDefaultIndex(List<String> availableVersions, String latestTagVersion) {
+        if (latestTagVersion != null) {
+            int index = availableVersions.indexOf(latestTagVersion);
+            if (index >= 0) {
+                return index;
+            }
+        }
+        return 0;
+    }
+
+    static int compareVersionsDesc(String left, String right) {
+        return compareVersions(right, left);
+    }
+
+    static int compareVersions(String left, String right) {
+        VersionParts leftParts = splitVersionParts(left);
+        VersionParts rightParts = splitVersionParts(right);
+        int baseCompare = compareBaseVersion(leftParts.base(), rightParts.base());
+        if (baseCompare != 0) {
+            return baseCompare;
+        }
+        return comparePrerelease(leftParts.prerelease(), rightParts.prerelease());
+    }
+
+    private static VersionParts splitVersionParts(String version) {
+        int dash = version.indexOf('-');
+        if (dash < 0) {
+            return new VersionParts(version, "");
+        }
+        return new VersionParts(version.substring(0, dash), version.substring(dash + 1));
+    }
+
+    private static int compareBaseVersion(String left, String right) {
+        String[] leftParts = left.split("\\.");
+        String[] rightParts = right.split("\\.");
+        int max = Math.max(leftParts.length, rightParts.length);
+        for (int i = 0; i < max; i++) {
+            String l = i < leftParts.length ? leftParts[i] : "";
+            String r = i < rightParts.length ? rightParts[i] : "";
+            int partCompare = compareVersionPart(l, r);
+            if (partCompare != 0) {
+                return partCompare;
+            }
+        }
+        return 0;
+    }
+
+    private static int comparePrerelease(String left, String right) {
+        if (left.isEmpty() && right.isEmpty()) {
+            return 0;
+        }
+        if (left.isEmpty()) {
+            return 1;
+        }
+        if (right.isEmpty()) {
+            return -1;
+        }
+        return left.compareToIgnoreCase(right);
+    }
+
+    private record VersionParts(String base, String prerelease) {
+    }
+
+    private static int compareVersionPart(String left, String right) {
+        boolean leftNumeric = left.matches("\\d+");
+        boolean rightNumeric = right.matches("\\d+");
+        if (leftNumeric && rightNumeric) {
+            return Integer.compare(Integer.parseInt(left), Integer.parseInt(right));
+        }
+        return left.compareToIgnoreCase(right);
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
@@ -58,7 +58,7 @@ public final class SpecificationPathResolver {
             Path targetDir = Paths.get(request.executionPath(), "spec",
                     FhirIgPackageDownloader.sanitizeIgDirectoryName(request.igName()));
             downloadIg(request, registryConfig, request.igName(), request.igVersion(), targetDir, downloadOptions);
-            String mapped = registryConfig.resolveDependentPackage(request.igName());
+            String mapped = registryConfig.resolveDependentPackage(request.igName(), request.igVersion());
             return new ResolvedSpecification(targetDir, request.igName(), mapped);
         }
 
@@ -78,7 +78,8 @@ public final class SpecificationPathResolver {
         Path targetDir = Paths.get(request.executionPath(), "spec",
                 HealthCmdConstants.CMD_DEFAULT_INTERNATIONAL_IG_DIR);
         downloadIg(request, registryConfig, defaultPkg.name(), defaultPkg.version(), targetDir, downloadOptions);
-        String mappedDependent = defaultDependentForIgPackage(defaultPkg.name(), registryConfig, request.igName());
+        String mappedDependent = defaultDependentForIgPackage(defaultPkg.name(), registryConfig, request.igName(),
+                request.igVersion());
         if (CMD_MODE_TEMPLATE.equals(request.mode())) {
             Path path = SpecificationPathUtils.resolveTemplateSpecificationPath(null, request.executionPath());
             return new ResolvedSpecification(path, defaultPkg.name(), mappedDependent);
@@ -87,8 +88,8 @@ public final class SpecificationPathResolver {
     }
 
     private static String defaultDependentForIgPackage(String packageName, IgRegistryConfig registryConfig,
-                                                       String igName) {
-        String mapped = igName != null ? registryConfig.resolveDependentPackage(igName) : null;
+                                                       String igName, String igVersion) {
+        String mapped = igName != null ? registryConfig.resolveDependentPackage(igName, igVersion) : null;
         if (mapped != null) {
             return mapped;
         }

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
@@ -24,6 +24,8 @@ import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Resolves FHIR specification directories, optionally downloading IG packages from the FHIR registry first.
@@ -54,23 +56,50 @@ public final class SpecificationPathResolver {
                 out
         );
 
-        if (request.igName() != null && !request.igName().isEmpty()) {
-            Path targetDir = Paths.get(request.executionPath(), "spec",
-                    FhirIgPackageDownloader.sanitizeIgDirectoryName(request.igName()));
-            downloadIg(request, registryConfig, request.igName(), request.igVersion(), targetDir, downloadOptions);
-            String mapped = registryConfig.resolveDependentPackage(request.igName(), request.igVersion());
-            return new ResolvedSpecification(targetDir, request.igName(), mapped);
+        if (!request.igReferences().isEmpty()) {
+            if (request.igReferences().size() == 1) {
+                // Single --ig: unchanged from before repeatable --ig support (leaf spec dir, handed to the
+                // framework as-is). Multi-IG (below) needs a different shape, so it's kept as its own branch
+                // rather than folding N=1 into the general case.
+                FhirIgPackageDownloader.ParsedIgSpec spec =
+                        FhirIgPackageDownloader.parseIgReference(request.igReferences().get(0));
+                Path targetDir = Paths.get(request.executionPath(), "spec",
+                        FhirIgPackageDownloader.sanitizeIgDirectoryName(spec.name()));
+                downloadIg(request, registryConfig, spec.name(), spec.version(), targetDir, downloadOptions);
+                String mapped = registryConfig.resolveDependentPackage(spec.name(), spec.version());
+                return new ResolvedSpecification(targetDir,
+                        List.of(new ResolvedIg(spec.name(), spec.version(), mapped)));
+            }
+
+            // Multi-IG: download each into its own spec/<name>/ (same per-IG mechanism as single --ig), and hand
+            // the framework their shared parent so it discovers all of them as sibling IGs in one pass -- mirrors
+            // the existing local spec-path convention of "one subfolder per IG".
+            Path specRoot = Paths.get(request.executionPath(), "spec");
+            List<ResolvedIg> resolvedIgs = new ArrayList<>();
+            for (String reference : request.igReferences()) {
+                FhirIgPackageDownloader.ParsedIgSpec spec = FhirIgPackageDownloader.parseIgReference(reference);
+                Path targetDir = specRoot.resolve(FhirIgPackageDownloader.sanitizeIgDirectoryName(spec.name()));
+                downloadIg(request, registryConfig, spec.name(), spec.version(), targetDir, downloadOptions);
+                String mapped = registryConfig.resolveDependentPackage(spec.name(), spec.version());
+                if (mapped == null) {
+                    throw new BallerinaHealthException("Multi-IG generation requires a known published Ballerina "
+                            + "package for every --ig (no packageMappings entry for " + spec.name() + "@"
+                            + spec.version() + "). Add one to tool-config.json, or generate this IG on its own.");
+                }
+                resolvedIgs.add(new ResolvedIg(spec.name(), spec.version(), mapped));
+            }
+            return new ResolvedSpecification(specRoot, resolvedIgs);
         }
 
         if (request.specPathArg() != null && !request.specPathArg().trim().isEmpty()) {
             if (CMD_MODE_TEMPLATE.equals(request.mode())) {
                 Path path = SpecificationPathUtils.resolveTemplateSpecificationPath(
                         request.specPathArg(), request.executionPath());
-                return new ResolvedSpecification(path, null, null);
+                return new ResolvedSpecification(path, List.of());
             }
             Path path = HealthCmdUtils.validateAndSetSpecificationPath(
                     request.specPathArg(), request.executionPath());
-            return new ResolvedSpecification(path, null, null);
+            return new ResolvedSpecification(path, List.of());
         }
 
         IgRegistryConfig.IgPackageRef defaultPkg = registryConfig.getDefaultPackage(
@@ -78,21 +107,15 @@ public final class SpecificationPathResolver {
         Path targetDir = Paths.get(request.executionPath(), "spec",
                 HealthCmdConstants.CMD_DEFAULT_INTERNATIONAL_IG_DIR);
         downloadIg(request, registryConfig, defaultPkg.name(), defaultPkg.version(), targetDir, downloadOptions);
-        String mappedDependent = defaultDependentForIgPackage(defaultPkg.name(), registryConfig, request.igName(),
-                request.igVersion());
+        String mappedDependent = defaultDependentForIgPackage(defaultPkg.name());
         if (CMD_MODE_TEMPLATE.equals(request.mode())) {
             Path path = SpecificationPathUtils.resolveTemplateSpecificationPath(null, request.executionPath());
-            return new ResolvedSpecification(path, defaultPkg.name(), mappedDependent);
+            return new ResolvedSpecification(path, List.of(new ResolvedIg(defaultPkg.name(), null, mappedDependent)));
         }
-        return new ResolvedSpecification(targetDir, defaultPkg.name(), mappedDependent);
+        return new ResolvedSpecification(targetDir, List.of(new ResolvedIg(defaultPkg.name(), null, mappedDependent)));
     }
 
-    private static String defaultDependentForIgPackage(String packageName, IgRegistryConfig registryConfig,
-                                                       String igName, String igVersion) {
-        String mapped = igName != null ? registryConfig.resolveDependentPackage(igName, igVersion) : null;
-        if (mapped != null) {
-            return mapped;
-        }
+    private static String defaultDependentForIgPackage(String packageName) {
         if (HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_NAME.equals(packageName)) {
             return HealthCmdConstants.CMD_DEFAULT_R5_DEPENDENT_PACKAGE;
         }
@@ -100,7 +123,7 @@ public final class SpecificationPathResolver {
     }
 
     public static boolean canResolveWithoutLocalSpec(ResolveRequest request) {
-        if (request.igName() != null && !request.igName().isEmpty()) {
+        if (!request.igReferences().isEmpty()) {
             return true;
         }
         if (request.specPathArg() != null && !request.specPathArg().trim().isEmpty()) {
@@ -136,8 +159,7 @@ public final class SpecificationPathResolver {
             String mode,
             String executionPath,
             String specPathArg,
-            String igName,
-            String igVersion,
+            List<String> igReferences,
             String registryUrl,
             String cacheDir,
             boolean forceDownload,
@@ -148,6 +170,12 @@ public final class SpecificationPathResolver {
     ) {
     }
 
-    public record ResolvedSpecification(Path specificationPath, String igPackageName, String mappedDependentPackage) {
+    /**
+     * One resolved {@code --ig} value: its real name/version, and the Ballerina package it maps to (if any).
+     */
+    public record ResolvedIg(String igName, String igVersion, String mappedDependentPackage) {
+    }
+
+    public record ResolvedSpecification(Path specificationPath, List<ResolvedIg> resolvedIgs) {
     }
 }

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import io.ballerina.health.cmd.core.config.IgRegistryConfig;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Resolves FHIR specification directories, optionally downloading IG packages from the FHIR registry first.
+ */
+public final class SpecificationPathResolver {
+
+    private SpecificationPathResolver() {
+    }
+
+    public static ResolvedSpecification resolve(ResolveRequest request) throws BallerinaHealthException {
+        IgRegistryConfig registryConfig = request.registryConfig() != null
+                ? request.registryConfig() : IgRegistryConfig.defaults();
+
+        String cacheDir = resolveCacheDir(request.cacheDir(), request.executionPath(), registryConfig.getCacheDir());
+        PrintStream out = request.printStream() != null ? request.printStream() : System.out;
+        FhirIgPackageDownloader.DownloadOptions downloadOptions = new FhirIgPackageDownloader.DownloadOptions(
+                request.registryUrl() != null ? request.registryUrl() : registryConfig.getRegistryUrl(),
+                cacheDir,
+                registryConfig.getHttpTimeoutSeconds(),
+                request.forceDownload(),
+                request.nonInteractive(),
+                out
+        );
+
+        if (request.igName() != null && !request.igName().isEmpty()) {
+            Path targetDir = Paths.get(request.executionPath(), "spec",
+                    FhirIgPackageDownloader.sanitizeIgDirectoryName(request.igName()));
+            downloadIg(request, registryConfig, request.igName(), request.igVersion(), targetDir, downloadOptions);
+            String mapped = registryConfig.resolveDependentPackage(request.igName());
+            return new ResolvedSpecification(targetDir, request.igName(), mapped);
+        }
+
+        if (request.specPathArg() != null && !request.specPathArg().trim().isEmpty()) {
+            if (CMD_MODE_TEMPLATE.equals(request.mode())) {
+                Path path = SpecificationPathUtils.resolveTemplateSpecificationPath(
+                        request.specPathArg(), request.executionPath());
+                return new ResolvedSpecification(path, null, null);
+            }
+            Path path = HealthCmdUtils.validateAndSetSpecificationPath(
+                    request.specPathArg(), request.executionPath());
+            return new ResolvedSpecification(path, null, null);
+        }
+
+        IgRegistryConfig.IgPackageRef defaultPkg = registryConfig.getDefaultPackage(
+                request.fhirVersion() != null ? request.fhirVersion() : "r4");
+        Path targetDir = Paths.get(request.executionPath(), "spec",
+                HealthCmdConstants.CMD_DEFAULT_INTERNATIONAL_IG_DIR);
+        downloadIg(request, registryConfig, defaultPkg.name(), defaultPkg.version(), targetDir, downloadOptions);
+        String mappedDependent = defaultDependentForIgPackage(defaultPkg.name(), registryConfig, request.igName());
+        if (CMD_MODE_TEMPLATE.equals(request.mode())) {
+            Path path = SpecificationPathUtils.resolveTemplateSpecificationPath(null, request.executionPath());
+            return new ResolvedSpecification(path, defaultPkg.name(), mappedDependent);
+        }
+        return new ResolvedSpecification(targetDir, defaultPkg.name(), mappedDependent);
+    }
+
+    private static String defaultDependentForIgPackage(String packageName, IgRegistryConfig registryConfig,
+                                                       String igName) {
+        String mapped = igName != null ? registryConfig.resolveDependentPackage(igName) : null;
+        if (mapped != null) {
+            return mapped;
+        }
+        if (HealthCmdConstants.CMD_DEFAULT_R5_IG_PACKAGE_NAME.equals(packageName)) {
+            return HealthCmdConstants.CMD_DEFAULT_R5_DEPENDENT_PACKAGE;
+        }
+        return HealthCmdConstants.CMD_DEFAULT_R4_DEPENDENT_PACKAGE;
+    }
+
+    public static boolean canResolveWithoutLocalSpec(ResolveRequest request) {
+        if (request.igName() != null && !request.igName().isEmpty()) {
+            return true;
+        }
+        if (request.specPathArg() != null && !request.specPathArg().trim().isEmpty()) {
+            return true;
+        }
+        return CMD_MODE_TEMPLATE.equals(request.mode()) || CMD_MODE_PACKAGE.equals(request.mode());
+    }
+
+    private static void downloadIg(ResolveRequest request, IgRegistryConfig registryConfig,
+                                   String packageName, String packageVersion, Path targetDir,
+                                   FhirIgPackageDownloader.DownloadOptions downloadOptions)
+            throws BallerinaHealthException {
+        FhirIgPackageDownloader.ParsedIgSpec spec =
+                FhirIgPackageDownloader.resolveIgSpec(packageName, packageVersion, downloadOptions);
+        PrintStream out = downloadOptions.printStream() != null ? downloadOptions.printStream() : System.out;
+        out.println(HealthCmdConstants.PrintStrings.IG_DOWNLOAD_SUCCESS + spec.source()
+                + " into " + targetDir + " ...");
+        FhirIgPackageDownloader.downloadAndExtract(targetDir, spec, downloadOptions);
+    }
+
+    private static String resolveCacheDir(String override, String executionPath, String configured) {
+        if (override != null && !override.isEmpty()) {
+            return Paths.get(override).isAbsolute()
+                    ? override : Paths.get(executionPath, override).toString();
+        }
+        return Paths.get(executionPath, configured).toString();
+    }
+
+    private static final String CMD_MODE_TEMPLATE = HealthCmdConstants.CMD_MODE_TEMPLATE;
+    private static final String CMD_MODE_PACKAGE = HealthCmdConstants.CMD_MODE_PACKAGE;
+
+    public record ResolveRequest(
+            String mode,
+            String executionPath,
+            String specPathArg,
+            String igName,
+            String igVersion,
+            String registryUrl,
+            String cacheDir,
+            boolean forceDownload,
+            boolean nonInteractive,
+            String fhirVersion,
+            IgRegistryConfig registryConfig,
+            PrintStream printStream
+    ) {
+    }
+
+    public record ResolvedSpecification(Path specificationPath, String igPackageName, String mappedDependentPackage) {
+    }
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathResolver.java
@@ -38,6 +38,10 @@ public final class SpecificationPathResolver {
                 ? request.registryConfig() : IgRegistryConfig.defaults();
 
         String cacheDir = resolveCacheDir(request.cacheDir(), request.executionPath(), registryConfig.getCacheDir());
+        boolean cacheDirExplicit = request.cacheDir() != null && !request.cacheDir().trim().isEmpty();
+        // resolveCacheDir() always returns an absolute path (it's joined against the absolute execution path),
+        // so "relative to the project" has to be judged from the raw --ig-cache-dir override, before resolution.
+        boolean cacheDirRelativeToProject = !cacheDirExplicit || !Paths.get(request.cacheDir().trim()).isAbsolute();
         PrintStream out = request.printStream() != null ? request.printStream() : System.out;
         FhirIgPackageDownloader.DownloadOptions downloadOptions = new FhirIgPackageDownloader.DownloadOptions(
                 request.registryUrl() != null ? request.registryUrl() : registryConfig.getRegistryUrl(),
@@ -45,6 +49,8 @@ public final class SpecificationPathResolver {
                 registryConfig.getHttpTimeoutSeconds(),
                 request.forceDownload(),
                 request.nonInteractive(),
+                cacheDirExplicit,
+                cacheDirRelativeToProject,
                 out
         );
 

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathUtils.java
@@ -93,6 +93,26 @@ public final class SpecificationPathUtils {
         return containsOnlyHl7BaseStructureDefinitions(specPath);
     }
 
+    /**
+     * Reads the {@code version} field from {@code directory/package.json} (the FHIR NPM package manifest),
+     * or {@code null} when the manifest or its version field is missing/unreadable.
+     */
+    public static String readInstalledPackageVersion(Path directory) {
+        Path packageJson = directory.resolve("package.json");
+        if (!Files.isRegularFile(packageJson)) {
+            return null;
+        }
+        try {
+            JsonObject json = JsonParser.parseString(Files.readString(packageJson)).getAsJsonObject();
+            if (!json.has("version") || json.get("version").getAsString().trim().isEmpty()) {
+                return null;
+            }
+            return json.get("version").getAsString().trim();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     public static boolean containsStructureDefinitionResources(Path directory) throws BallerinaHealthException {
         try {
             if (!Files.isDirectory(directory)) {

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathUtils.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/core/utils/SpecificationPathUtils.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Resolves FHIR specification directories for template generation, including the
+ * international base R4 structure-definition layout documented under spec-path/international.
+ */
+public final class SpecificationPathUtils {
+
+    private static final String INTERNATIONAL_IG_DIR = "international";
+    private static final String STRUCTURE_DEFINITION_PREFIX = "StructureDefinition";
+    private static final String HL7_BASE_STRUCTURE_DEFINITION_URL_PREFIX =
+            "http://hl7.org/fhir/StructureDefinition/";
+
+    private SpecificationPathUtils() {
+    }
+
+    /**
+     * Resolves the directory that contains FHIR structure definitions for template generation.
+     * When the given path is a spec root (with IG subfolders), the international subdirectory is used.
+     * When no path is given, {@code <executionPath>/spec/international} is used.
+     */
+    public static Path resolveTemplateSpecificationPath(String specPathParam, String executionPath)
+            throws BallerinaHealthException {
+        if (specPathParam != null && !specPathParam.trim().isEmpty()) {
+            Path specificationPath = HealthCmdUtils.getSpecificationPath(specPathParam, executionPath);
+            if (!Files.isDirectory(specificationPath)) {
+                throw new BallerinaHealthException("Cannot find valid spec path pointed. Please check the path "
+                        + specPathParam + " is valid.");
+            }
+            if (containsStructureDefinitionResources(specificationPath)) {
+                return specificationPath;
+            }
+            Path internationalPath = specificationPath.resolve(INTERNATIONAL_IG_DIR);
+            if (Files.isDirectory(internationalPath) && containsStructureDefinitionResources(internationalPath)) {
+                return internationalPath;
+            }
+            throw new BallerinaHealthException("No FHIR StructureDefinition resources found under "
+                    + specificationPath + ". Point to an IG folder or to a spec root that contains an '"
+                    + INTERNATIONAL_IG_DIR + "' directory with HL7 international base R4 definitions.");
+        }
+
+        Path defaultInternationalPath = Paths.get(executionPath, "spec", INTERNATIONAL_IG_DIR);
+        if (Files.isDirectory(defaultInternationalPath) && containsStructureDefinitionResources(defaultInternationalPath)) {
+            return defaultInternationalPath;
+        }
+        throw new BallerinaHealthException("No IG specification path provided. Either pass the path to FHIR "
+                + "definitions as the last argument, or place HL7 international base R4 StructureDefinition "
+                + "files under spec/international relative to the working directory.");
+    }
+
+    /**
+     * Returns true when the specification path only contains HL7 international base structure definitions
+     * (no regional or custom implementation guide profiles).
+     */
+    public static boolean isInternationalBaseSpecification(String specificationPath) throws IOException {
+        Path specPath = Path.of(specificationPath);
+        if (specPath.getFileName() != null
+                && INTERNATIONAL_IG_DIR.equalsIgnoreCase(specPath.getFileName().toString())) {
+            return true;
+        }
+        if (hasCustomImplementationGuide(specPath)) {
+            return false;
+        }
+        return containsOnlyHl7BaseStructureDefinitions(specPath);
+    }
+
+    public static boolean containsStructureDefinitionResources(Path directory) throws BallerinaHealthException {
+        try {
+            if (!Files.isDirectory(directory)) {
+                return false;
+            }
+            try (Stream<Path> paths = Files.walk(directory, 2)) {
+                return paths
+                        .filter(Files::isRegularFile)
+                        .filter(path -> path.getFileName().toString().startsWith(STRUCTURE_DEFINITION_PREFIX))
+                        .anyMatch(SpecificationPathUtils::isStructureDefinitionFile);
+            }
+        } catch (IOException e) {
+            throw new BallerinaHealthException("Unable to read specification path: " + directory, e);
+        }
+    }
+
+    private static boolean hasCustomImplementationGuide(Path specificationPath) throws IOException {
+        try (Stream<Path> paths = Files.walk(specificationPath, 2)) {
+            List<Path> implementationGuideFiles = paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().startsWith("ImplementationGuide")
+                            || path.getFileName().toString().contains("ImplementationGuide"))
+                    .toList();
+
+            for (Path path : implementationGuideFiles) {
+                try {
+                    JsonObject json = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+                    if (!json.has("resourceType")
+                            || !"ImplementationGuide".equals(json.get("resourceType").getAsString())) {
+                        continue;
+                    }
+                    if (json.has("packageId") && !json.get("packageId").getAsString().isEmpty()) {
+                        return true;
+                    }
+                    if (json.has("name") && !json.get("name").getAsString().isEmpty()
+                            && !"FHIR".equalsIgnoreCase(json.get("name").getAsString())) {
+                        return true;
+                    }
+                } catch (Exception ignored) {
+                    // try next candidate file
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsOnlyHl7BaseStructureDefinitions(Path specificationPath) throws IOException {
+        boolean foundStructureDefinition = false;
+        try (Stream<Path> paths = Files.walk(specificationPath, 2)) {
+            List<Path> structureDefinitionFiles = paths
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().startsWith(STRUCTURE_DEFINITION_PREFIX))
+                    .toList();
+
+            for (Path path : structureDefinitionFiles) {
+                if (!isStructureDefinitionFile(path)) {
+                    continue;
+                }
+                foundStructureDefinition = true;
+                try {
+                    JsonObject json = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+                    if (!json.has("url")) {
+                        return false;
+                    }
+                    String url = json.get("url").getAsString();
+                    if (!url.startsWith(HL7_BASE_STRUCTURE_DEFINITION_URL_PREFIX)) {
+                        return false;
+                    }
+                    String resourceName = url.substring(HL7_BASE_STRUCTURE_DEFINITION_URL_PREFIX.length());
+                    if (resourceName.contains("/")) {
+                        return false;
+                    }
+                } catch (Exception e) {
+                    return false;
+                }
+            }
+        }
+        return foundStructureDefinition;
+    }
+
+    private static boolean isStructureDefinitionFile(Path path) {
+        try {
+            JsonObject json = JsonParser.parseString(Files.readString(path)).getAsJsonObject();
+            return json.has("resourceType")
+                    && "StructureDefinition".equals(json.get("resourceType").getAsString());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -108,6 +108,9 @@ public class FhirSubCmd implements BLauncherCmd {
     @CommandLine.Option(names = "--minimal", description = "Enable minimal generation mode to skip .choreo folder, OAS files, .gitignore, and Ballerina.toml. Only generates core service files")
     private boolean minimal;
 
+    @CommandLine.Option(names = "--flat", description = "Aggregated mode only. Generate directly into -o/--output instead of nesting under fhir-service/. Keeps Ballerina.toml, .gitignore, OAS, and .choreo (unlike --minimal). No effect with --aggregate false")
+    private boolean flat;
+
     @CommandLine.Option(names = "--ig", description = "FHIR registry package reference as <name>[@version] (npm-style), e.g. hl7.fhir.us.core@8.0.1. Downloads from the registry when no local spec path is given. When the version is omitted, the CLI interactively lists published versions (or picks dist-tags.latest when run non-interactively)")
     private String ig;
 
@@ -315,6 +318,7 @@ public class FhirSubCmd implements BLauncherCmd {
         argsMap.put("--aggregate", aggregate);
         argsMap.put("--resources", resources);
         argsMap.put("--minimal", minimal);
+        argsMap.put("--flat", flat);
 
         Handler toolHandler = null;
         try {

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.logging.LogManager;
 
 import io.ballerina.health.cmd.core.config.IgRegistryConfig;
+import io.ballerina.health.cmd.core.utils.FhirIgPackageDownloader;
 import io.ballerina.health.cmd.core.utils.IgModuleNameUtils;
 import io.ballerina.health.cmd.core.utils.IgRegistryConfigLoader;
 import io.ballerina.health.cmd.core.utils.SpecificationPathResolver;
@@ -107,14 +108,8 @@ public class FhirSubCmd implements BLauncherCmd {
     @CommandLine.Option(names = "--minimal", description = "Enable minimal generation mode to skip .choreo folder, OAS files, .gitignore, and Ballerina.toml. Only generates core service files")
     private boolean minimal;
 
-    @CommandLine.Option(names = "--ig-name", description = "FHIR registry package id (e.g. hl7.fhir.us.core). Downloads from packages.fhir.org when no local spec path is given")
-    private String igName;
-
-    @CommandLine.Option(names = "--ig-version", description = "FHIR registry package version (e.g. 6.1.0). If omitted, interactively selects from published versions (or dist-tags.latest with --non-interactive)")
-    private String igVersion;
-
-    @CommandLine.Option(names = "--non-interactive", description = "Skip interactive IG version selection; use dist-tags.latest when --ig-version is omitted")
-    private boolean nonInteractive;
+    @CommandLine.Option(names = "--ig", description = "FHIR registry package reference as <name>[@version] (npm-style), e.g. hl7.fhir.us.core@8.0.1. Downloads from the registry when no local spec path is given. When the version is omitted, the CLI interactively lists published versions (or picks dist-tags.latest when run non-interactively)")
+    private String ig;
 
     @CommandLine.Option(names = "--registry-url", description = "FHIR package registry base URL (default: https://packages.fhir.org)")
     private String registryUrl;
@@ -171,8 +166,13 @@ public class FhirSubCmd implements BLauncherCmd {
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
+        if (ig != null && !ig.trim().isEmpty() && !FhirIgPackageDownloader.isValidIgReference(ig)) {
+            printStream.println(HealthCmdConstants.PrintStrings.IG_REFERENCE_INVALID);
+            printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
+            HealthCmdUtils.exitError(exitWhenFinish);
+        }
         if (CMD_MODE_PACKAGE.equals(mode) && (argList == null || argList.isEmpty())
-                && (igName == null || igName.isEmpty()) && !canResolveSpecificationFromRegistry()) {
+                && (igName() == null || igName().isEmpty()) && !canResolveSpecificationFromRegistry()) {
             printStream.println(HealthCmdConstants.PrintStrings.SPEC_PATH_REQUIRED);
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
@@ -191,7 +191,7 @@ public class FhirSubCmd implements BLauncherCmd {
         }
         if (CMD_MODE_TEMPLATE.equals(mode) &&
                 (dependentPackage == null || dependentPackage.isEmpty()) &&
-                (igName == null || igName.isEmpty()) &&
+                (igName() == null || igName().isEmpty()) &&
                 !canResolveSpecificationFromRegistry()) {
             printStream.println(HealthCmdConstants.PrintStrings.DEPENDENT_REQUIRED);
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
@@ -278,12 +278,12 @@ public class FhirSubCmd implements BLauncherCmd {
                                 mode,
                                 executionPath.toString(),
                                 specPathArg,
-                                igName,
-                                igVersion,
+                                igName(),
+                                igVersion(),
                                 registryUrl,
                                 igCacheDir,
                                 forceIgDownload,
-                                nonInteractive,
+                                false,
                                 null,
                                 registryConfig,
                                 printStream
@@ -328,11 +328,8 @@ public class FhirSubCmd implements BLauncherCmd {
         return toolHandler.execute(specificationPath.toString(), targetOutputPath.toString());
     }
 
-    /**
-     * This util is to get the output Path.
-     */
     private boolean canResolveSpecificationFromRegistry() {
-        if (igName != null && !igName.isEmpty()) {
+        if (igName() != null && !igName().isEmpty()) {
             return true;
         }
         if (argList != null && !argList.isEmpty()) {
@@ -343,17 +340,37 @@ public class FhirSubCmd implements BLauncherCmd {
                         mode,
                         executionPath.toString(),
                         null,
-                        igName,
-                        igVersion,
+                        igName(),
+                        igVersion(),
                         registryUrl,
                         igCacheDir,
                         forceIgDownload,
-                        nonInteractive,
+                        false,
                         null,
                         IgRegistryConfigLoader.load(),
                         printStream
                 ));
     }
+
+    /**
+     * Package name component of --ig (before the last '@'), or null when --ig isn't set.
+     */
+    private String igName() {
+        return (ig == null || ig.trim().isEmpty()) ? null
+                : FhirIgPackageDownloader.parseIgReference(ig).name();
+    }
+
+    /**
+     * Version component of --ig (after the last '@'), or null when --ig isn't set.
+     */
+    private String igVersion() {
+        return (ig == null || ig.trim().isEmpty()) ? null
+                : FhirIgPackageDownloader.parseIgReference(ig).version();
+    }
+
+    /**
+     * This util is to get the output Path.
+     */
 
     private void getTargetOutputPath() {
         targetOutputPath = executionPath;

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -36,6 +36,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,7 @@ public class FhirSubCmd implements BLauncherCmd {
 
     //resolved path from the input parameter
     private Path specificationPath;
+    private List<SpecificationPathResolver.ResolvedIg> resolvedIgs = List.of();
     @CommandLine.Option(names = {"--help", "-h", "?"}, usageHelp = true, hidden = true)
     private boolean helpFlag;
 
@@ -111,8 +113,8 @@ public class FhirSubCmd implements BLauncherCmd {
     @CommandLine.Option(names = "--flat", description = "Aggregated mode only. Generate directly into -o/--output instead of nesting under fhir-service/. Keeps Ballerina.toml, .gitignore, OAS, and .choreo (unlike --minimal). No effect with --aggregate false")
     private boolean flat;
 
-    @CommandLine.Option(names = "--ig", description = "FHIR registry package reference as <name>[@version] (npm-style), e.g. hl7.fhir.us.core@8.0.1. Downloads from the registry when no local spec path is given. When the version is omitted, the CLI interactively lists published versions (or picks dist-tags.latest when run non-interactively)")
-    private String ig;
+    @CommandLine.Option(names = "--ig", description = "FHIR registry package reference as <name>[@version] (npm-style), e.g. hl7.fhir.us.core@8.0.1. Downloads from the registry when no local spec path is given. When the version is omitted, the CLI interactively lists published versions (or picks dist-tags.latest when run non-interactively). Repeatable: pass --ig more than once (template mode only) to merge profiles from multiple IGs for the same resource type into one service, dispatched by _profile -- every IG in a multi-IG run must have a known packageMappings entry")
+    private String[] ig;
 
     @CommandLine.Option(names = "--registry-url", description = "FHIR package registry base URL (default: https://packages.fhir.org)")
     private String registryUrl;
@@ -169,13 +171,26 @@ public class FhirSubCmd implements BLauncherCmd {
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
-        if (ig != null && !ig.trim().isEmpty() && !FhirIgPackageDownloader.isValidIgReference(ig)) {
-            printStream.println(HealthCmdConstants.PrintStrings.IG_REFERENCE_INVALID);
+        for (String reference : igReferences()) {
+            if (!FhirIgPackageDownloader.isValidIgReference(reference)) {
+                printStream.println(HealthCmdConstants.PrintStrings.IG_REFERENCE_INVALID);
+                printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
+                HealthCmdUtils.exitError(exitWhenFinish);
+                break;
+            }
+        }
+        if (igReferences().size() > 1 && !CMD_MODE_TEMPLATE.equals(mode)) {
+            printStream.println(HealthCmdConstants.PrintStrings.MULTI_IG_TEMPLATE_ONLY);
+            printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
+            HealthCmdUtils.exitError(exitWhenFinish);
+        }
+        if (igReferences().size() > 1 && dependentPackage != null && !dependentPackage.isEmpty()) {
+            printStream.println(HealthCmdConstants.PrintStrings.MULTI_IG_DEPENDENT_PACKAGE_CONFLICT);
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
         if (CMD_MODE_PACKAGE.equals(mode) && (argList == null || argList.isEmpty())
-                && (igName() == null || igName().isEmpty()) && !canResolveSpecificationFromRegistry()) {
+                && !hasIg() && !canResolveSpecificationFromRegistry()) {
             printStream.println(HealthCmdConstants.PrintStrings.SPEC_PATH_REQUIRED);
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
@@ -194,7 +209,7 @@ public class FhirSubCmd implements BLauncherCmd {
         }
         if (CMD_MODE_TEMPLATE.equals(mode) &&
                 (dependentPackage == null || dependentPackage.isEmpty()) &&
-                (igName() == null || igName().isEmpty()) &&
+                !hasIg() &&
                 !canResolveSpecificationFromRegistry()) {
             printStream.println(HealthCmdConstants.PrintStrings.DEPENDENT_REQUIRED);
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
@@ -281,8 +296,7 @@ public class FhirSubCmd implements BLauncherCmd {
                                 mode,
                                 executionPath.toString(),
                                 specPathArg,
-                                igName(),
-                                igVersion(),
+                                igReferences(),
                                 registryUrl,
                                 igCacheDir,
                                 forceIgDownload,
@@ -292,10 +306,11 @@ public class FhirSubCmd implements BLauncherCmd {
                                 printStream
                         ));
                 specificationPath = resolved.specificationPath();
-                if (CMD_MODE_TEMPLATE.equals(mode) && !explicitDependentPackage
-                        && resolved.mappedDependentPackage() != null) {
-                    printStream.println("[INFO] IG " + resolved.igPackageName()
-                            + " maps to published package " + resolved.mappedDependentPackage()
+                resolvedIgs = resolved.resolvedIgs();
+                if (CMD_MODE_TEMPLATE.equals(mode) && !explicitDependentPackage && resolvedIgs.size() == 1
+                        && resolvedIgs.get(0).mappedDependentPackage() != null) {
+                    printStream.println("[INFO] IG " + resolvedIgs.get(0).igName()
+                            + " maps to published package " + resolvedIgs.get(0).mappedDependentPackage()
                             + ". Embedding IG resources in the template (use --dependent-package to import that package instead).");
                 }
             } catch (BallerinaHealthException e) {
@@ -319,10 +334,12 @@ public class FhirSubCmd implements BLauncherCmd {
         argsMap.put("--resources", resources);
         argsMap.put("--minimal", minimal);
         argsMap.put("--flat", flat);
+        argsMap.put("--resolved-igs", resolvedIgs);
 
         Handler toolHandler = null;
         try {
-            toolHandler = HandlerFactory.createHandler(toolName, mode, printStream, specificationPath.toString());
+            toolHandler = HandlerFactory.createHandler(
+                    toolName, mode, printStream, specificationPath.toString(), resolvedIgs);
         } catch (BallerinaHealthException e) {
             printStream.println(e);
             throw new BLauncherException();
@@ -333,7 +350,7 @@ public class FhirSubCmd implements BLauncherCmd {
     }
 
     private boolean canResolveSpecificationFromRegistry() {
-        if (igName() != null && !igName().isEmpty()) {
+        if (hasIg()) {
             return true;
         }
         if (argList != null && !argList.isEmpty()) {
@@ -344,8 +361,7 @@ public class FhirSubCmd implements BLauncherCmd {
                         mode,
                         executionPath.toString(),
                         null,
-                        igName(),
-                        igVersion(),
+                        igReferences(),
                         registryUrl,
                         igCacheDir,
                         forceIgDownload,
@@ -357,19 +373,20 @@ public class FhirSubCmd implements BLauncherCmd {
     }
 
     /**
-     * Package name component of --ig (before the last '@'), or null when --ig isn't set.
+     * Trimmed, non-empty --ig values in the order given (possibly more than one -- see --ig's repeatable usage).
      */
-    private String igName() {
-        return (ig == null || ig.trim().isEmpty()) ? null
-                : FhirIgPackageDownloader.parseIgReference(ig).name();
+    private List<String> igReferences() {
+        if (ig == null || ig.length == 0) {
+            return List.of();
+        }
+        return Arrays.stream(ig)
+                .filter(value -> value != null && !value.trim().isEmpty())
+                .map(String::trim)
+                .toList();
     }
 
-    /**
-     * Version component of --ig (after the last '@'), or null when --ig isn't set.
-     */
-    private String igVersion() {
-        return (ig == null || ig.trim().isEmpty()) ? null
-                : FhirIgPackageDownloader.parseIgReference(ig).version();
+    private boolean hasIg() {
+        return !igReferences().isEmpty();
     }
 
     /**

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/fhir/FhirSubCmd.java
@@ -41,6 +41,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.LogManager;
 
+import io.ballerina.health.cmd.core.config.IgRegistryConfig;
+import io.ballerina.health.cmd.core.utils.IgModuleNameUtils;
+import io.ballerina.health.cmd.core.utils.IgRegistryConfigLoader;
+import io.ballerina.health.cmd.core.utils.SpecificationPathResolver;
+
 import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.*;
 
 @CommandLine.Command(name = "fhir", description = "Generates Ballerina service/client for FHIR contract " +
@@ -87,11 +92,14 @@ public class FhirSubCmd implements BLauncherCmd {
     @CommandLine.Option(names = "--dependent-package", description = "Dependent package name for the templates to be generated")
     private String dependentPackage;
 
+    @CommandLine.Option(names = "--ig-module-name", description = "Optional module name for embedded IG resources (default: inferred from the IG). Ignored when --dependent-package is set")
+    private String igModuleName;
+
     @CommandLine.Option(names = "--dependent-ig", description = "Dependent IG base URL and respective fully qualified Ballerina package name")
     private String[] dependentIgs;
 
-    @CommandLine.Option(names = "--aggregate", description = "Enable aggregated API mode to generate a single service with multiple FHIR resources")
-    private boolean aggregate;
+    @CommandLine.Option(names = "--aggregate", description = "Aggregated API mode (default: true). Pass --aggregate false for separate services per resource", defaultValue = "true", fallbackValue = "true", arity = "0..1")
+    private boolean aggregate = true;
 
     @CommandLine.Option(names = "--resources", description = "Comma-separated list of FHIR resources to include. If not specified, all available resources will be included")
     private String resources;
@@ -99,6 +107,23 @@ public class FhirSubCmd implements BLauncherCmd {
     @CommandLine.Option(names = "--minimal", description = "Enable minimal generation mode to skip .choreo folder, OAS files, .gitignore, and Ballerina.toml. Only generates core service files")
     private boolean minimal;
 
+    @CommandLine.Option(names = "--ig-name", description = "FHIR registry package id (e.g. hl7.fhir.us.core). Downloads from packages.fhir.org when no local spec path is given")
+    private String igName;
+
+    @CommandLine.Option(names = "--ig-version", description = "FHIR registry package version (e.g. 6.1.0). If omitted, interactively selects from published versions (or dist-tags.latest with --non-interactive)")
+    private String igVersion;
+
+    @CommandLine.Option(names = "--non-interactive", description = "Skip interactive IG version selection; use dist-tags.latest when --ig-version is omitted")
+    private boolean nonInteractive;
+
+    @CommandLine.Option(names = "--registry-url", description = "FHIR package registry base URL (default: https://packages.fhir.org)")
+    private String registryUrl;
+
+    @CommandLine.Option(names = "--ig-cache-dir", description = "Directory to cache downloaded IG .tgz files (default: .fhir-ig-cache under the working directory)")
+    private String igCacheDir;
+
+    @CommandLine.Option(names = "--force-ig-download", description = "Re-download and re-extract the IG package even if definitions already exist locally")
+    private boolean forceIgDownload;
 
     @CommandLine.Parameters(description = "Custom arguments")
     private List<String> argList;
@@ -140,9 +165,15 @@ public class FhirSubCmd implements BLauncherCmd {
             printStream.println(HealthCmdConstants.PrintStrings.HELP_ERROR);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
-        if (!CMD_CONNECTOR.equals(mode) && (argList == null || argList.isEmpty())) {
-            //at minimum arg count is 1 (spec path)
+        if (!CMD_CONNECTOR.equals(mode) && !CMD_MODE_TEMPLATE.equals(mode) && !CMD_MODE_PACKAGE.equals(mode)
+                && (argList == null || argList.isEmpty())) {
             printStream.println(HealthCmdConstants.PrintStrings.INVALID_NUM_OF_ARGS);
+            printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
+            HealthCmdUtils.exitError(exitWhenFinish);
+        }
+        if (CMD_MODE_PACKAGE.equals(mode) && (argList == null || argList.isEmpty())
+                && (igName == null || igName.isEmpty()) && !canResolveSpecificationFromRegistry()) {
+            printStream.println(HealthCmdConstants.PrintStrings.SPEC_PATH_REQUIRED);
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
@@ -158,8 +189,10 @@ public class FhirSubCmd implements BLauncherCmd {
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
-        if (CMD_MODE_TEMPLATE.equals(mode) && (dependentPackage == null || dependentPackage.isEmpty())) {
-            // dependent package is a required param in template mode
+        if (CMD_MODE_TEMPLATE.equals(mode) &&
+                (dependentPackage == null || dependentPackage.isEmpty()) &&
+                (igName == null || igName.isEmpty()) &&
+                !canResolveSpecificationFromRegistry()) {
             printStream.println(HealthCmdConstants.PrintStrings.DEPENDENT_REQUIRED);
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
@@ -172,9 +205,9 @@ public class FhirSubCmd implements BLauncherCmd {
                 HealthCmdUtils.exitError(exitWhenFinish);
             }
         }
-        if (CMD_MODE_TEMPLATE.equals(mode) && (dependentPackage == null || dependentPackage.isEmpty())) {
-            // dependent package is a required param in template mode
-            printStream.println(HealthCmdConstants.PrintStrings.DEPENDENT_REQUIRED);
+        if (!CMD_CONNECTOR.equals(mode) && igModuleName != null && !igModuleName.isEmpty()
+                && !IgModuleNameUtils.isValidBallerinaModuleName(igModuleName)) {
+            printStream.println("Invalid IG module name.");
             printStream.println(HealthCmdConstants.PrintStrings.HELP_FOR_MORE_INFO);
             HealthCmdUtils.exitError(exitWhenFinish);
         }
@@ -226,20 +259,9 @@ public class FhirSubCmd implements BLauncherCmd {
     }
 
     public boolean engageSubCommand(String mode, List<String> argList) {
-
-        Map<String, Object> argsMap = new HashMap<>();
-        argsMap.put("--package-name", packageName);
-        argsMap.put("--org-name", orgName);
-        argsMap.put("--package-version", packageVersion);
-        argsMap.put("--included-profile", includedProfiles);
-        argsMap.put("--excluded-profile", excludedProfiles);
-        argsMap.put("--dependent-package", dependentPackage);
-        argsMap.put("--dependent-ig", dependentIgs);
-        argsMap.put("--aggregate", aggregate);
-        argsMap.put("--resources", resources);
-        argsMap.put("--minimal", minimal);
         getTargetOutputPath();
 
+        boolean explicitDependentPackage = dependentPackage != null && !dependentPackage.isEmpty();
         if (CMD_MODE_CONNECTOR.equals(mode)) {
             try {
                 specificationPath = HealthCmdUtils.getSpecificationPath(configPath, executionPath.toString());
@@ -248,14 +270,51 @@ public class FhirSubCmd implements BLauncherCmd {
                 throw new BLauncherException();
             }
         } else {
-            //spec path is the last argument
             try {
-                specificationPath = HealthCmdUtils.validateAndSetSpecificationPath(argList.get(argList.size() - 1), executionPath.toString());
+                String specPathArg = (argList == null || argList.isEmpty()) ? null : argList.get(argList.size() - 1);
+                IgRegistryConfig registryConfig = IgRegistryConfigLoader.load();
+                SpecificationPathResolver.ResolvedSpecification resolved =
+                        SpecificationPathResolver.resolve(new SpecificationPathResolver.ResolveRequest(
+                                mode,
+                                executionPath.toString(),
+                                specPathArg,
+                                igName,
+                                igVersion,
+                                registryUrl,
+                                igCacheDir,
+                                forceIgDownload,
+                                nonInteractive,
+                                null,
+                                registryConfig,
+                                printStream
+                        ));
+                specificationPath = resolved.specificationPath();
+                if (CMD_MODE_TEMPLATE.equals(mode) && !explicitDependentPackage
+                        && resolved.mappedDependentPackage() != null) {
+                    printStream.println("[INFO] IG " + resolved.igPackageName()
+                            + " maps to published package " + resolved.mappedDependentPackage()
+                            + ". Embedding IG resources in the template (use --dependent-package to import that package instead).");
+                }
             } catch (BallerinaHealthException e) {
+                printStream.println(e.getMessage());
                 printStream.println(HealthCmdConstants.PrintStrings.INVALID_SPEC_PATH);
                 throw new BLauncherException();
             }
         }
+
+        Map<String, Object> argsMap = new HashMap<>();
+        argsMap.put("--package-name", packageName);
+        argsMap.put("--org-name", orgName);
+        argsMap.put("--package-version", packageVersion);
+        argsMap.put("--included-profile", includedProfiles);
+        argsMap.put("--excluded-profile", excludedProfiles);
+        argsMap.put("--explicit-dependent-package", explicitDependentPackage);
+        argsMap.put("--dependent-package", explicitDependentPackage ? dependentPackage : null);
+        argsMap.put("--ig-module-name", igModuleName);
+        argsMap.put("--dependent-ig", dependentIgs);
+        argsMap.put("--aggregate", aggregate);
+        argsMap.put("--resources", resources);
+        argsMap.put("--minimal", minimal);
 
         Handler toolHandler = null;
         try {
@@ -272,6 +331,30 @@ public class FhirSubCmd implements BLauncherCmd {
     /**
      * This util is to get the output Path.
      */
+    private boolean canResolveSpecificationFromRegistry() {
+        if (igName != null && !igName.isEmpty()) {
+            return true;
+        }
+        if (argList != null && !argList.isEmpty()) {
+            return true;
+        }
+        return SpecificationPathResolver.canResolveWithoutLocalSpec(
+                new SpecificationPathResolver.ResolveRequest(
+                        mode,
+                        executionPath.toString(),
+                        null,
+                        igName,
+                        igVersion,
+                        registryUrl,
+                        igCacheDir,
+                        forceIgDownload,
+                        nonInteractive,
+                        null,
+                        IgRegistryConfigLoader.load(),
+                        printStream
+                ));
+    }
+
     private void getTargetOutputPath() {
         targetOutputPath = executionPath;
         if (this.outputPath != null) {

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
@@ -159,6 +159,10 @@ public class FhirTemplateGenHandler implements Handler {
                     JsonElement overrideConfig = new Gson().toJsonTree(fhirVersion.toLowerCase());
                     toolConfigInstance.overrideConfig("project.fhir.default_version", overrideConfig);
                 }
+                if (packageName != null && !packageName.isEmpty()) {
+                    JsonElement overrideConfig = new Gson().toJsonTree(packageName.toLowerCase());
+                    toolConfigInstance.overrideConfig("project.package.templateName", overrideConfig);
+                }
                 if (generateIgModule) {
                     String resolvedIgModuleName = resolveIgModuleName(specificationPath);
                     String igModuleSourcePath = generateIgModuleSource(specificationPath, targetOutputPath,

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
@@ -66,6 +66,7 @@ public class FhirTemplateGenHandler implements Handler {
     private boolean aggregate;
     private String resources;
     private boolean minimal;
+    private boolean flat;
 
     private JsonObject configJson;
     private PrintStream printStream;
@@ -102,6 +103,7 @@ public class FhirTemplateGenHandler implements Handler {
         Object aggregateArg = argsMap.get("--aggregate");
         this.aggregate = aggregateArg instanceof Boolean ? (Boolean) aggregateArg : true;
         this.minimal = (Boolean) argsMap.get("--minimal");
+        this.flat = Boolean.TRUE.equals(argsMap.get("--flat"));
         this.resources = (String) argsMap.get("--resources");
     }
 
@@ -200,6 +202,9 @@ public class FhirTemplateGenHandler implements Handler {
                 if (minimal) {
                     JsonElement minimalConfig = new Gson().toJsonTree(true);
                     toolConfigInstance.overrideConfig("project.minimalGeneration", minimalConfig);
+                }
+                if (flat) {
+                    toolConfigInstance.overrideConfig("project.flatOutput", new Gson().toJsonTree(true));
                 }
 
                 Object toolFactory = toolClass.getConstructor().newInstance();

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
@@ -27,16 +27,25 @@ import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
 import io.ballerina.health.cmd.core.utils.ErrorMessages;
 import io.ballerina.health.cmd.core.utils.HealthCmdConstants;
 import io.ballerina.health.cmd.core.utils.HealthCmdUtils;
+import io.ballerina.health.cmd.core.utils.IgModuleNameUtils;
+import io.ballerina.health.cmd.core.utils.SpecificationPathUtils;
 import org.wso2.healthcare.codegen.tool.framework.commons.config.ToolConfig;
 import org.wso2.healthcare.codegen.tool.framework.commons.core.TemplateGenerator;
 import org.wso2.healthcare.codegen.tool.framework.commons.core.Tool;
 import org.wso2.healthcare.codegen.tool.framework.commons.exception.CodeGenException;
 import org.wso2.healthcare.codegen.tool.framework.commons.model.JsonConfigType;
 import org.wso2.healthcare.codegen.tool.framework.fhir.core.FHIRTool;
+import org.wso2.healthcare.fhir.ballerina.packagegen.tool.BallerinaPackageGenTool;
+import org.wso2.healthcare.fhir.ballerina.packagegen.tool.config.BallerinaPackageGenToolConfig;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 /**
@@ -49,6 +58,8 @@ public class FhirTemplateGenHandler implements Handler {
     private String packageVersion;
     private String fhirVersion;
     private String dependentPackage;
+    private boolean generateIgModule;
+    private String igModuleName;
 
     private String[] includedProfiles;
     private String[] excludedProfiles;
@@ -83,15 +94,24 @@ public class FhirTemplateGenHandler implements Handler {
         this.orgName = (String) argsMap.get("--org-name");
         this.packageVersion = (String) argsMap.get("--package-version");
         this.dependentPackage = (String) argsMap.get("--dependent-package");
+        boolean explicitDependentPackage = Boolean.TRUE.equals(argsMap.get("--explicit-dependent-package"));
+        this.generateIgModule = !explicitDependentPackage;
+        this.igModuleName = (String) argsMap.get("--ig-module-name");
         this.includedProfiles = (String[]) argsMap.get("--included-profile");
         this.excludedProfiles = (String[]) argsMap.get("--excluded-profile");
-        this.aggregate = (Boolean) argsMap.get("--aggregate");
+        Object aggregateArg = argsMap.get("--aggregate");
+        this.aggregate = aggregateArg instanceof Boolean ? (Boolean) aggregateArg : true;
         this.minimal = (Boolean) argsMap.get("--minimal");
         this.resources = (String) argsMap.get("--resources");
     }
 
     @Override
     public boolean execute(String specificationPath, String targetOutputPath) {
+        try {
+            applyInternationalBaseDefaults(specificationPath);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to evaluate specification path for template generation", e);
+        }
 
         JsonElement toolExecConfigs = null;
         if (configJson != null) {
@@ -137,35 +157,44 @@ public class FhirTemplateGenHandler implements Handler {
                     JsonElement overrideConfig = new Gson().toJsonTree(fhirVersion.toLowerCase());
                     toolConfigInstance.overrideConfig("project.fhir.default_version", overrideConfig);
                 }
-                if (dependentPackage != null) {
-                    JsonElement overrideConfig = new Gson().toJsonTree(dependentPackage);
-                    JsonElement nameConfig =
-                            new Gson().toJsonTree(dependentPackage.substring(dependentPackage.lastIndexOf('/') + 1));
-                    toolConfigInstance.overrideConfig("project.package.dependentPackage", overrideConfig);
-                    toolConfigInstance.overrideConfig("project.package.namePrefix", nameConfig);
+                if (generateIgModule) {
+                    String resolvedIgModuleName = resolveIgModuleName(specificationPath);
+                    String igModuleSourcePath = generateIgModuleSource(specificationPath, targetOutputPath,
+                            toolExecConfig);
+                    JsonElement generateIgModuleEnabled = new Gson().toJsonTree(true);
+                    JsonElement generateIgModuleNameConfig = new Gson().toJsonTree(resolvedIgModuleName);
+                    JsonElement generateIgModuleSourceDir = new Gson().toJsonTree(igModuleSourcePath);
+                    toolConfigInstance.overrideConfig("project.generateIgModule.enabled", generateIgModuleEnabled);
+                    toolConfigInstance.overrideConfig("project.generateIgModule.name", generateIgModuleNameConfig);
+                    toolConfigInstance.overrideConfig("project.generateIgModule.sourceDir", generateIgModuleSourceDir);
+                } else {
+                    toolConfigInstance.overrideConfig("project.generateIgModule.enabled", new Gson().toJsonTree(false));
+                    if (dependentPackage != null && !dependentPackage.isEmpty()) {
+                        JsonElement overrideConfig = new Gson().toJsonTree(dependentPackage);
+                        JsonElement nameConfig = new Gson().toJsonTree(
+                                dependentPackage.substring(dependentPackage.lastIndexOf('/') + 1));
+                        toolConfigInstance.overrideConfig("project.package.dependentPackage", overrideConfig);
+                        toolConfigInstance.overrideConfig("project.package.namePrefix", nameConfig);
+                    }
                 }
                 toolConfigInstance.overrideConfig("project.package.igConfig", populateIGConfig(
                                 HealthCmdConstants.CMD_DEFAULT_IG_NAME,
                                 orgName,
+                                getEffectiveDependentPackage(),
                                 includedProfiles,
                                 excludedProfiles
                         )
                 );
 
-                // Configure aggregated API settings
-                if (aggregate) {
-                    JsonElement aggregateConfig = new Gson().toJsonTree(true);
-                    toolConfigInstance.overrideConfig("project.enableAggregatedApi", aggregateConfig);
-
-                    if (resources != null && !resources.trim().isEmpty()) {
-                        // Parse comma-separated resources and create JSON array
-                        String[] resourceArray = resources.split(",");
-                        JsonArray resourcesArray = new JsonArray();
-                        for (String resource : resourceArray) {
-                            resourcesArray.add(resource.trim());
-                        }
-                        toolConfigInstance.overrideConfig("project.aggregatedApis", resourcesArray);
+                // Configure aggregated API settings (default: enabled)
+                toolConfigInstance.overrideConfig("project.enableAggregatedApi", new Gson().toJsonTree(aggregate));
+                if (aggregate && resources != null && !resources.trim().isEmpty()) {
+                    String[] resourceArray = resources.split(",");
+                    JsonArray resourcesArray = new JsonArray();
+                    for (String resource : resourceArray) {
+                        resourcesArray.add(resource.trim());
                     }
+                    toolConfigInstance.overrideConfig("project.aggregatedApis", resourcesArray);
                 }
                 // Configure minimal generation settings
                 if (minimal) {
@@ -220,12 +249,121 @@ public class FhirTemplateGenHandler implements Handler {
         return false;
     }
 
-    private JsonObject populateIGConfig(String name, String orgName, String[] includedProfiles,
-                                        String[] excludedProfiles) {
+    private String resolveIgModuleName(String specificationPath) {
+        if (igModuleName != null && !igModuleName.isEmpty()) {
+            return igModuleName;
+        }
+        try {
+            return IgModuleNameUtils.inferIgModuleName(specificationPath);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to infer IG module name from specification", e);
+        }
+    }
+
+    private String generateIgModuleSource(String specificationPath, String targetOutputPath,
+                                          JsonObject toolExecConfig) {
+        try {
+            BallerinaPackageGenToolConfig packageToolConfig = new BallerinaPackageGenToolConfig();
+            String generatedIgPackagePath = Paths.get(targetOutputPath, ".generated-ig-package").toString();
+            Path generatedIgPackagePathObj = Paths.get(generatedIgPackagePath);
+            if (Files.exists(generatedIgPackagePathObj)) {
+                deleteRecursively(generatedIgPackagePathObj.toFile());
+            }
+            packageToolConfig.setTargetDir(generatedIgPackagePath);
+            packageToolConfig.setToolName(HealthCmdConstants.CMD_MODE_PACKAGE);
+            JsonObject packageExecConfig = configJson.getAsJsonObject("fhir").getAsJsonObject("tools")
+                    .getAsJsonObject(HealthCmdConstants.CMD_MODE_PACKAGE).getAsJsonObject("config");
+            packageToolConfig.configure(new JsonConfigType(packageExecConfig));
+
+            String packageNameToGenerate = getPackageNameForIgModule(packageExecConfig);
+            packageToolConfig.overrideConfig("packageConfig.name", new Gson().toJsonTree(packageNameToGenerate));
+            if (orgName != null && !orgName.isEmpty()) {
+                packageToolConfig.overrideConfig("packageConfig.org", new Gson().toJsonTree(orgName.toLowerCase()));
+            }
+            if (packageVersion != null && !packageVersion.isEmpty()) {
+                packageToolConfig.overrideConfig("packageConfig.packageVersion",
+                        new Gson().toJsonTree(packageVersion.toLowerCase()));
+            }
+            if (fhirVersion != null && !fhirVersion.isEmpty()) {
+                packageToolConfig.overrideConfig("packageConfig.fhirVersion", new Gson().toJsonTree(fhirVersion));
+            }
+
+            Tool packageTool = new BallerinaPackageGenTool();
+            packageTool.initialize(packageToolConfig);
+            TemplateGenerator packageTemplateGenerator = packageTool.execute(fhirToolLib.getToolContext());
+            if (packageTemplateGenerator != null) {
+                packageTemplateGenerator.generate(
+                        fhirToolLib.getToolContext(), packageTemplateGenerator.getGeneratorProperties());
+                HealthCmdUtils.engageChildTemplateGenerators(
+                        packageTemplateGenerator.getChildTemplateGenerator(),
+                        fhirToolLib.getToolContext(), packageTemplateGenerator.getGeneratorProperties());
+            }
+            return Paths.get(generatedIgPackagePath, packageNameToGenerate).toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Error generating IG module source package", e);
+        }
+    }
+
+    private String getPackageNameForIgModule(JsonObject packageExecConfigObj) {
+        if (packageName != null && !packageName.isEmpty()) {
+            return packageName;
+        }
+        if (dependentPackage != null && dependentPackage.contains("/")) {
+            return dependentPackage.substring(dependentPackage.lastIndexOf('/') + 1);
+        }
+        return packageExecConfigObj.getAsJsonObject("packageConfigs").getAsJsonPrimitive("name").getAsString();
+    }
+
+    private void deleteRecursively(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        if (!file.delete()) {
+            throw new RuntimeException("Failed to delete file: " + file.getAbsolutePath());
+        }
+    }
+
+    private void applyInternationalBaseDefaults(String specificationPath) throws IOException {
+        boolean useInternationalBase = SpecificationPathUtils.isInternationalBaseSpecification(specificationPath);
+        if ((dependentPackage == null || dependentPackage.isEmpty()) && useInternationalBase) {
+            dependentPackage = getDefaultDependentPackageForFhirVersion();
+            printStream.println(HealthCmdConstants.PrintStrings.USING_INTERNATIONAL_BASE + dependentPackage + ".");
+        }
+        if (generateIgModule && useInternationalBase) {
+            generateIgModule = false;
+            printStream.println("[INFO] International base structure definitions detected. "
+                    + "Using published dependent package " + dependentPackage + " instead of embedding an IG module.");
+        }
+    }
+
+    private String getDefaultDependentPackageForFhirVersion() {
+        if (fhirVersion != null && fhirVersion.equalsIgnoreCase("r5")) {
+            return HealthCmdConstants.CMD_DEFAULT_R5_DEPENDENT_PACKAGE;
+        }
+        return HealthCmdConstants.CMD_DEFAULT_R4_DEPENDENT_PACKAGE;
+    }
+
+    private String getEffectiveDependentPackage() {
+        if (dependentPackage != null && !dependentPackage.isEmpty()) {
+            return dependentPackage;
+        }
+        return getDefaultDependentPackageForFhirVersion();
+    }
+
+    private JsonObject populateIGConfig(String name, String orgName, String dependentPackageName,
+                                        String[] includedProfiles, String[] excludedProfiles) {
 
         JsonObject igConfig = new JsonObject();
         igConfig.addProperty("implementationGuide", name);
-        String importStatement = orgName != null ? orgName : HealthCmdConstants.CMD_DEFAULT_ORG_NAME + "/" + name;
+        String importStatement = dependentPackageName;
+        if (orgName != null && !orgName.isEmpty() && !dependentPackageName.contains("/")) {
+            importStatement = orgName + "/" + dependentPackageName;
+        }
         igConfig.addProperty("importStatement", importStatement);
         igConfig.addProperty("enable", true);
         JsonArray includedProfilesArray = new JsonArray();

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/FhirTemplateGenHandler.java
@@ -25,16 +25,21 @@ import com.google.gson.JsonObject;
 import io.ballerina.health.cmd.core.config.HealthCmdConfig;
 import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
 import io.ballerina.health.cmd.core.utils.ErrorMessages;
+import io.ballerina.health.cmd.core.utils.FhirIgPackageDownloader;
 import io.ballerina.health.cmd.core.utils.HealthCmdConstants;
 import io.ballerina.health.cmd.core.utils.HealthCmdUtils;
 import io.ballerina.health.cmd.core.utils.IgModuleNameUtils;
+import io.ballerina.health.cmd.core.utils.SpecificationPathResolver;
 import io.ballerina.health.cmd.core.utils.SpecificationPathUtils;
 import org.wso2.healthcare.codegen.tool.framework.commons.config.ToolConfig;
 import org.wso2.healthcare.codegen.tool.framework.commons.core.TemplateGenerator;
 import org.wso2.healthcare.codegen.tool.framework.commons.core.Tool;
 import org.wso2.healthcare.codegen.tool.framework.commons.exception.CodeGenException;
 import org.wso2.healthcare.codegen.tool.framework.commons.model.JsonConfigType;
+import org.wso2.healthcare.codegen.tool.framework.fhir.core.AbstractFHIRSpecParser;
+import org.wso2.healthcare.codegen.tool.framework.fhir.core.FHIRSpecParserFactory;
 import org.wso2.healthcare.codegen.tool.framework.fhir.core.FHIRTool;
+import org.wso2.healthcare.codegen.tool.framework.fhir.core.config.FHIRToolConfig;
 import org.wso2.healthcare.fhir.ballerina.packagegen.tool.BallerinaPackageGenTool;
 import org.wso2.healthcare.fhir.ballerina.packagegen.tool.config.BallerinaPackageGenToolConfig;
 
@@ -46,6 +51,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -60,6 +66,7 @@ public class FhirTemplateGenHandler implements Handler {
     private String dependentPackage;
     private boolean generateIgModule;
     private String igModuleName;
+    private List<SpecificationPathResolver.ResolvedIg> resolvedIgs;
 
     private String[] includedProfiles;
     private String[] excludedProfiles;
@@ -75,17 +82,69 @@ public class FhirTemplateGenHandler implements Handler {
 
     @Override
     public void init(PrintStream printStream, String specificationPath) {
+        init(printStream, specificationPath, List.of());
+    }
+
+    @Override
+    public void init(PrintStream printStream, String specificationPath,
+                     List<SpecificationPathResolver.ResolvedIg> resolvedIgs) {
 
         this.printStream = printStream;
+        this.resolvedIgs = resolvedIgs;
         try {
             configJson = HealthCmdConfig.getParsedConfigFromStream(HealthCmdUtils.getResourceFile(
                     this.getClass(), HealthCmdConstants.CMD_CONFIG_FILENAME));
         } catch (BallerinaHealthException e) {
             throw new RuntimeException(e);
         }
-        fhirToolLib = (FHIRTool) initializeLib(
-                HealthCmdConstants.CMD_SUB_FHIR, printStream, configJson, specificationPath);
+        if (isMultiIg()) {
+            fhirToolLib = initializeMultiIgLib(printStream, specificationPath, resolvedIgs);
+        } else {
+            fhirToolLib = (FHIRTool) initializeLib(
+                    HealthCmdConstants.CMD_SUB_FHIR, printStream, configJson, specificationPath);
+        }
         fhirVersion = fhirToolLib.getFhirVersion();
+    }
+
+    /**
+     * Multi-IG equivalent of {@link Handler#initializeLib}: that default only ever calls
+     * {@code specParser.parseIG(fhirToolConfig, "FHIR", specificationPath)} once, treating the whole given path
+     * as one IG's own directory (no subfolder discovery happens anywhere in the framework -- confirmed by reading
+     * its source). For multi-IG, parseIG needs to be called once per resolved IG, each with its own real name and
+     * its own spec/&lt;name&gt; leaf directory (the framework maps FHIRImplementationGuide by whatever name it's
+     * called with, independent of file content), so that each profile parsed keeps its own IG identity for the
+     * per-IG package resolution in FHIRProfile.setPackagePrefix().
+     */
+    private FHIRTool initializeMultiIgLib(PrintStream printStream, String specBasePath,
+                                          List<SpecificationPathResolver.ResolvedIg> resolvedIgs) {
+        try {
+            String detectedFhirVersion = HealthCmdUtils.getSpecFhirVersion(specBasePath);
+            if (detectedFhirVersion == null) {
+                printStream.println(ErrorMessages.LIB_INITIALIZING_FAILED
+                        + "Unable to find FHIR version in the specification");
+                return null;
+            }
+            FHIRToolConfig fhirToolConfig = new FHIRToolConfig();
+            fhirToolConfig.configure(new JsonConfigType(configJson));
+            fhirToolConfig.setSpecBasePath(specBasePath);
+            FHIRTool multiIgToolLib = new FHIRTool(detectedFhirVersion);
+            multiIgToolLib.initialize(fhirToolConfig);
+
+            AbstractFHIRSpecParser specParser = FHIRSpecParserFactory.getParser(detectedFhirVersion);
+            for (SpecificationPathResolver.ResolvedIg resolvedIg : resolvedIgs) {
+                String igDir = Paths.get(specBasePath,
+                        FhirIgPackageDownloader.sanitizeIgDirectoryName(resolvedIg.igName())).toString();
+                specParser.parseIG(fhirToolConfig, resolvedIg.igName(), igDir);
+            }
+            return multiIgToolLib;
+        } catch (IOException e) {
+            printStream.println(ErrorMessages.FHIR_VERSION_READ_ERROR + e.getMessage());
+            return null;
+        } catch (CodeGenException e) {
+            printStream.println(ErrorMessages.LIB_INITIALIZING_FAILED + e.getMessage());
+            HealthCmdUtils.throwLauncherException(e);
+            return null;
+        }
     }
 
     @Override
@@ -105,14 +164,27 @@ public class FhirTemplateGenHandler implements Handler {
         this.minimal = (Boolean) argsMap.get("--minimal");
         this.flat = Boolean.TRUE.equals(argsMap.get("--flat"));
         this.resources = (String) argsMap.get("--resources");
+        @SuppressWarnings("unchecked")
+        List<SpecificationPathResolver.ResolvedIg> resolved =
+                (List<SpecificationPathResolver.ResolvedIg>) argsMap.get("--resolved-igs");
+        this.resolvedIgs = resolved;
+    }
+
+    private boolean isMultiIg() {
+        return resolvedIgs != null && resolvedIgs.size() > 1;
     }
 
     @Override
     public boolean execute(String specificationPath, String targetOutputPath) {
-        try {
-            applyInternationalBaseDefaults(specificationPath);
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to evaluate specification path for template generation", e);
+        if (!isMultiIg()) {
+            // The international-base-default detection below reads the whole specification path looking for
+            // one, tool-wide dependent package -- meaningless once every IG already has its own resolved
+            // package (see the multi-IG branch in the igConfig block further down).
+            try {
+                applyInternationalBaseDefaults(specificationPath);
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to evaluate specification path for template generation", e);
+            }
         }
 
         JsonElement toolExecConfigs = null;
@@ -163,34 +235,52 @@ public class FhirTemplateGenHandler implements Handler {
                     JsonElement overrideConfig = new Gson().toJsonTree(packageName.toLowerCase());
                     toolConfigInstance.overrideConfig("project.package.templateName", overrideConfig);
                 }
-                if (generateIgModule) {
-                    String resolvedIgModuleName = resolveIgModuleName(specificationPath);
-                    String igModuleSourcePath = generateIgModuleSource(specificationPath, targetOutputPath,
-                            toolExecConfig);
-                    JsonElement generateIgModuleEnabled = new Gson().toJsonTree(true);
-                    JsonElement generateIgModuleNameConfig = new Gson().toJsonTree(resolvedIgModuleName);
-                    JsonElement generateIgModuleSourceDir = new Gson().toJsonTree(igModuleSourcePath);
-                    toolConfigInstance.overrideConfig("project.generateIgModule.enabled", generateIgModuleEnabled);
-                    toolConfigInstance.overrideConfig("project.generateIgModule.name", generateIgModuleNameConfig);
-                    toolConfigInstance.overrideConfig("project.generateIgModule.sourceDir", generateIgModuleSourceDir);
-                } else {
+                if (isMultiIg()) {
+                    // Every IG in a multi-IG run already resolved to a known published package (enforced in
+                    // SpecificationPathResolver) -- never embed, and give each IG its own igConfig entry keyed
+                    // by its real name instead of the single "FHIR" constant used below, so the profiles the
+                    // framework discovers per real IG name (see AbstractBallerinaProjectTool.populateIGs())
+                    // line up with a matching config entry.
                     toolConfigInstance.overrideConfig("project.generateIgModule.enabled", new Gson().toJsonTree(false));
-                    if (dependentPackage != null && !dependentPackage.isEmpty()) {
-                        JsonElement overrideConfig = new Gson().toJsonTree(dependentPackage);
-                        JsonElement nameConfig = new Gson().toJsonTree(
-                                dependentPackage.substring(dependentPackage.lastIndexOf('/') + 1));
-                        toolConfigInstance.overrideConfig("project.package.dependentPackage", overrideConfig);
-                        toolConfigInstance.overrideConfig("project.package.namePrefix", nameConfig);
-                    }
-                }
-                toolConfigInstance.overrideConfig("project.package.igConfig", populateIGConfig(
-                                HealthCmdConstants.CMD_DEFAULT_IG_NAME,
+                    for (SpecificationPathResolver.ResolvedIg resolvedIg : resolvedIgs) {
+                        toolConfigInstance.overrideConfig("project.package.igConfig", populateIGConfig(
+                                resolvedIg.igName(),
                                 orgName,
-                                getEffectiveDependentPackage(),
+                                resolvedIg.mappedDependentPackage(),
                                 includedProfiles,
                                 excludedProfiles
-                        )
-                );
+                        ));
+                    }
+                } else {
+                    if (generateIgModule) {
+                        String resolvedIgModuleName = resolveIgModuleName(specificationPath);
+                        String igModuleSourcePath = generateIgModuleSource(specificationPath, targetOutputPath,
+                                toolExecConfig);
+                        JsonElement generateIgModuleEnabled = new Gson().toJsonTree(true);
+                        JsonElement generateIgModuleNameConfig = new Gson().toJsonTree(resolvedIgModuleName);
+                        JsonElement generateIgModuleSourceDir = new Gson().toJsonTree(igModuleSourcePath);
+                        toolConfigInstance.overrideConfig("project.generateIgModule.enabled", generateIgModuleEnabled);
+                        toolConfigInstance.overrideConfig("project.generateIgModule.name", generateIgModuleNameConfig);
+                        toolConfigInstance.overrideConfig("project.generateIgModule.sourceDir", generateIgModuleSourceDir);
+                    } else {
+                        toolConfigInstance.overrideConfig("project.generateIgModule.enabled", new Gson().toJsonTree(false));
+                        if (dependentPackage != null && !dependentPackage.isEmpty()) {
+                            JsonElement overrideConfig = new Gson().toJsonTree(dependentPackage);
+                            JsonElement nameConfig = new Gson().toJsonTree(
+                                    dependentPackage.substring(dependentPackage.lastIndexOf('/') + 1));
+                            toolConfigInstance.overrideConfig("project.package.dependentPackage", overrideConfig);
+                            toolConfigInstance.overrideConfig("project.package.namePrefix", nameConfig);
+                        }
+                    }
+                    toolConfigInstance.overrideConfig("project.package.igConfig", populateIGConfig(
+                                    HealthCmdConstants.CMD_DEFAULT_IG_NAME,
+                                    orgName,
+                                    getEffectiveDependentPackage(),
+                                    includedProfiles,
+                                    excludedProfiles
+                            )
+                    );
+                }
 
                 // Configure aggregated API settings (default: enabled)
                 toolConfigInstance.overrideConfig("project.enableAggregatedApi", new Gson().toJsonTree(aggregate));

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/Handler.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/Handler.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import io.ballerina.health.cmd.core.utils.ErrorMessages;
 import io.ballerina.health.cmd.core.utils.HealthCmdConstants;
 import io.ballerina.health.cmd.core.utils.HealthCmdUtils;
+import io.ballerina.health.cmd.core.utils.SpecificationPathResolver;
 import org.wso2.healthcare.codegen.tool.framework.commons.core.AbstractTool;
 import org.wso2.healthcare.codegen.tool.framework.commons.exception.CodeGenException;
 import org.wso2.healthcare.codegen.tool.framework.commons.model.JsonConfigType;
@@ -33,6 +34,7 @@ import org.wso2.healthcare.codegen.tool.framework.fhir.core.config.FHIRToolConfi
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -92,6 +94,16 @@ public interface Handler {
     }
 
     void init(PrintStream printStream, String specificationPath);
+
+    /**
+     * Same as {@link #init(PrintStream, String)}, but also given the resolved {@code --ig} values (name,
+     * version, mapped package). Only handlers that support multi-IG generation need to override this --
+     * the default just ignores resolvedIgs and delegates to the single-path init.
+     */
+    default void init(PrintStream printStream, String specificationPath,
+                      List<SpecificationPathResolver.ResolvedIg> resolvedIgs) {
+        init(printStream, specificationPath);
+    }
 
     void setArgs(Map<String, Object> argsMap);
 

--- a/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/HandlerFactory.java
+++ b/native/health-cli/src/main/java/io/ballerina/health/cmd/handler/HandlerFactory.java
@@ -20,8 +20,10 @@ package io.ballerina.health.cmd.handler;
 
 import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
 import io.ballerina.health.cmd.core.utils.ErrorMessages;
+import io.ballerina.health.cmd.core.utils.SpecificationPathResolver;
 
 import java.io.PrintStream;
+import java.util.List;
 
 import static io.ballerina.health.cmd.core.utils.HealthCmdConstants.*;
 
@@ -32,11 +34,23 @@ public class HandlerFactory {
 
     public static Handler createHandler(String subCommand, String mode, PrintStream printStream, String specificationPath)
             throws BallerinaHealthException {
+        return createHandler(subCommand, mode, printStream, specificationPath, List.of());
+    }
+
+    /**
+     * Same as the 4-arg overload, but additionally passes the resolved {@code --ig} values through to the
+     * handler's {@code init} -- only {@code FhirTemplateGenHandler} (fhir:template) uses these today, for
+     * multi-IG generation; every other case ignores resolvedIgs and behaves exactly as before.
+     */
+    public static Handler createHandler(String subCommand, String mode, PrintStream printStream,
+                                        String specificationPath,
+                                        List<SpecificationPathResolver.ResolvedIg> resolvedIgs)
+            throws BallerinaHealthException {
 
         switch (subCommand + SEMICOLON + mode) {
             case CMD_FHIR_MODE_TEMPLATE:
                 Handler templateHandler = new FhirTemplateGenHandler();
-                templateHandler.init(printStream, specificationPath);
+                templateHandler.init(printStream, specificationPath, resolvedIgs);
                 return templateHandler;
 
             case CMD_FHIR_MODE_CLIENT:

--- a/native/health-cli/src/main/resources/ballerina-health.help
+++ b/native/health-cli/src/main/resources/ballerina-health.help
@@ -4,11 +4,11 @@ NAME
 
 SYNOPSIS
         bal health fhir [-m | --mode] package --package-name <package-name> \
-                        [--ig-name <registry-package-id>] [--ig-version <version>] \
+                        [--ig <name>[@<version>]] \
                         [-o <output>] [<FHIR-specification-directory-path>]
 
         bal health fhir [-m | --mode] template \
-                        [--ig-name <registry-package-id>] [--ig-version <version>] \
+                        [--ig <name>[@<version>]] \
                         [--dependent-package <qualified-ballerina-package-name>] \
                         [--aggregate <true|false>] [-o <output>] \
                         [<FHIR-specification-directory-path>]
@@ -26,9 +26,9 @@ DESCRIPTION
 
         FHIR specification files can be provided as a local directory path (last
         positional argument), or downloaded automatically from the FHIR package
-        registry (https://packages.fhir.org) using --ig-name and --ig-version.
-        The specification path is optional when --ig-name is set, or in template
-        mode when the default HL7 R4 core IG should be used.
+        registry (https://packages.fhir.org) using --ig <name>[@<version>], e.g.
+        --ig hl7.fhir.us.core@8.0.1. The specification path is optional when --ig
+        is set, or in template mode when the default HL7 R4 core IG should be used.
 
         Template mode defaults:
             - A single aggregated FHIR API under fhir-service/ (--aggregate
@@ -38,13 +38,14 @@ DESCRIPTION
               --ig-module-name is set). Pass --dependent-package to import a
               published package instead and skip local IG module generation.
 
-        When no path or --ig-name is given in template mode, the tool downloads
+        When no path or --ig is given in template mode, the tool downloads
         hl7.fhir.r4.core into spec/international and imports the published
         ballerinax/health.fhir.r4.international401 package (no local IG module).
 
-        When --ig-version is omitted for a registry download, the CLI lists
-        published versions interactively (TTY). Use --non-interactive in CI or
-        scripts to select dist-tags.latest automatically.
+        When the version is omitted from --ig (e.g. --ig hl7.fhir.us.core), the
+        CLI lists published versions interactively when run from a terminal, or
+        automatically selects dist-tags.latest when run non-interactively (CI,
+        scripts, or any environment without a TTY).
 
         You can also obtain FHIR specification files from the respective
         Implementation Guide's official website. (Published list of
@@ -98,20 +99,15 @@ COMMANDS
                         a prefix on generated template imports. When omitted,
                         profile types are embedded under fhir-service/modules/.
 
-                    --ig-name <registry-package-id>
-                        FHIR package registry id (e.g. hl7.fhir.us.core).
-                        Downloads from packages.fhir.org into spec/<ig-name>
-                        when no local specification path is provided. Works in
-                        both 'package' and 'template' modes.
-
-                    --ig-version <version>
-                        Registry package version (e.g. 6.1.0 or 9.0.0). If
-                        omitted, an interactive list of published versions is
-                        shown (TTY). Use --non-interactive for dist-tags.latest.
-
-                    --non-interactive
-                        When --ig-version is omitted, use dist-tags.latest from
-                        registry metadata without prompting (for CI and scripts).
+                    --ig <name>[@<version>]
+                        FHIR registry package reference, npm-style (e.g.
+                        hl7.fhir.us.core@8.0.1, or bare hl7.fhir.us.core for the
+                        latest version). Downloads from packages.fhir.org into
+                        spec/<name> when no local specification path is
+                        provided. Works in both 'package' and 'template' modes.
+                        When the version is omitted, an interactive list of
+                        published versions is shown when run from a terminal;
+                        otherwise dist-tags.latest is selected automatically.
 
                     --registry-url <url>
                         FHIR package registry base URL (default:
@@ -119,7 +115,12 @@ COMMANDS
 
                     --ig-cache-dir <path>
                         Directory for cached .tgz downloads (default:
-                        .fhir-ig-cache under the working directory).
+                        .fhir-ig-cache under the working directory). If a
+                        package is already downloaded, place it here as
+                        <name>-<version>.tgz to skip the network fetch. When
+                        this flag is explicitly set and the expected archive
+                        isn't found, a warning is printed before falling back
+                        to a registry download.
 
                     --force-ig-download
                         Re-download and re-extract the IG even if definitions
@@ -193,22 +194,23 @@ COMMANDS
 
                     Generate templates from US Core via the registry (embedded IG
                     module, aggregated service; pick version interactively).
-                        $ bal health fhir -m template --ig-name hl7.fhir.us.core \
+                        $ bal health fhir -m template --ig hl7.fhir.us.core \
                         -o ./generated-template
 
-                    Pin a US Core registry version (non-interactive CI example).
-                        $ bal health fhir -m template --ig-name hl7.fhir.us.core \
-                        --ig-version 9.0.0 --non-interactive -o ./generated-template
+                    Pin a US Core registry version (non-interactive CI example;
+                    dist-tags.latest is used automatically outside a terminal).
+                        $ bal health fhir -m template --ig hl7.fhir.us.core@9.0.0 \
+                        -o ./generated-template
 
                     Generate templates using a published US Core package instead
                     of an embedded local module.
                         $ bal health fhir -m template \
                         --dependent-package ballerinax/health.fhir.r4.uscore501 \
-                        --ig-name hl7.fhir.us.core --ig-version 6.1.0 \
+                        --ig hl7.fhir.us.core@6.1.0 \
                         -o ./generated-template
 
                     Generate separate services per FHIR resource.
-                        $ bal health fhir -m template --ig-name hl7.fhir.us.core \
+                        $ bal health fhir -m template --ig hl7.fhir.us.core \
                         --aggregate false -o ./generated-template
 
                     Generate a Ballerina package from local US Core definitions.
@@ -217,8 +219,8 @@ COMMANDS
 
                     Generate a package from US Core via the FHIR package registry.
                         $ bal health fhir -m package --package-name uscore501 \
-                        --org-name ballerinax --ig-name hl7.fhir.us.core \
-                        --ig-version 6.1.0 -o ./output
+                        --org-name ballerinax --ig hl7.fhir.us.core@6.1.0 \
+                        -o ./output
 
                     Generate templates from local US Core definitions (embedded
                     IG module by default).

--- a/native/health-cli/src/main/resources/ballerina-health.help
+++ b/native/health-cli/src/main/resources/ballerina-health.help
@@ -10,8 +10,8 @@ SYNOPSIS
         bal health fhir [-m | --mode] template \
                         [--ig <name>[@<version>]] \
                         [--dependent-package <qualified-ballerina-package-name>] \
-                        [--aggregate <true|false>] [-o <output>] \
-                        [<FHIR-specification-directory-path>]
+                        [--aggregate <true|false>] [--package-name <name-of-package>] \
+                        [-o <output>] [<FHIR-specification-directory-path>]
 
         bal health fhir [-m | --mode] connector --config <config-file-path> \
                         -o <output>
@@ -77,8 +77,13 @@ COMMANDS
                         This is a MANDATORY input for the fhir command.
 
                     --package-name <name-of-package>
-                        Only applicable in 'package' mode. Name of the Ballerina
-                        package to be generated. MANDATORY in 'package' mode.
+                        MANDATORY in 'package' mode: name of the Ballerina
+                        package to be generated.
+                        Optional in aggregated template mode: names the
+                        generated project (Ballerina.toml and the embedded
+                        IG module's import prefix). Defaults to
+                        FHIRServerTemplate when omitted. No effect with
+                        --aggregate false.
                         Refer https://ballerina.io/learn/package-references/#the-name-field
 
                     --dependent-ig <base-url-of-the-IG>=<qualified-ballerina-package-name>

--- a/native/health-cli/src/main/resources/ballerina-health.help
+++ b/native/health-cli/src/main/resources/ballerina-health.help
@@ -169,6 +169,13 @@ COMMANDS
                         Generates only core service files and skips .choreo,
                         OAS, .gitignore, and Ballerina.toml.
 
+                    --flat
+                        Aggregated mode only (default --aggregate; no effect
+                        with --aggregate false). Generates directly into
+                        -o/--output instead of nesting under fhir-service/.
+                        Unlike --minimal, still generates Ballerina.toml,
+                        .gitignore, OAS, and .choreo.
+
                     -c, --config <config-file-path>
                         MANDATORY in 'connector' mode. Path to the configuration
                         JSON file including the FHIR server Capability Statement
@@ -212,6 +219,11 @@ COMMANDS
                     Generate separate services per FHIR resource.
                         $ bal health fhir -m template --ig hl7.fhir.us.core \
                         --aggregate false -o ./generated-template
+
+                    Generate the aggregated service directly into -o, without
+                    the fhir-service/ subdirectory.
+                        $ bal health fhir -m template --ig hl7.fhir.us.core \
+                        --flat -o ./generated-template
 
                     Generate a Ballerina package from local US Core definitions.
                         $ bal health fhir -m package --package-name uscore401 \

--- a/native/health-cli/src/main/resources/ballerina-health.help
+++ b/native/health-cli/src/main/resources/ballerina-health.help
@@ -1,25 +1,52 @@
 NAME
         ballerina-health - Generate a Ballerina package or template for a
-        given health specification (eg.:FHIR implementation guides) files.
+        given health specification (eg.: FHIR implementation guides) files.
 
 SYNOPSIS
         bal health fhir [-m | --mode] package --package-name <package-name> \
-                        <FHIR-specification-directory-path>
-                        [-m | --mode] template --dependent-package <dependent-package> \
-                        <FHIR-specification-directory-path>
-                        [-m | --mode] connector --config <config-file-path> \
-                        --output <output>
+                        [--ig-name <registry-package-id>] [--ig-version <version>] \
+                        [-o <output>] [<FHIR-specification-directory-path>]
+
+        bal health fhir [-m | --mode] template \
+                        [--ig-name <registry-package-id>] [--ig-version <version>] \
+                        [--dependent-package <qualified-ballerina-package-name>] \
+                        [--aggregate <true|false>] [-o <output>] \
+                        [<FHIR-specification-directory-path>]
+
+        bal health fhir [-m | --mode] connector --config <config-file-path> \
+                        -o <output>
 
 
 DESCRIPTION
         Generate a Ballerina package or template with relevant records and types
-        from a given health specification (eg.:FHIR implementation guides) files.
+        from a given health specification (eg.: FHIR implementation guides) files.
 
-        The generated Ballerina sources will be written into the provided
-        output location. Make sure to add the directory path which contains
-        FHIR specification, as the last argument.
+        The generated Ballerina sources are written to the output location given
+        with -o/--output, or to the current working directory when omitted.
 
-        You can download FHIR specification files from the respective
+        FHIR specification files can be provided as a local directory path (last
+        positional argument), or downloaded automatically from the FHIR package
+        registry (https://packages.fhir.org) using --ig-name and --ig-version.
+        The specification path is optional when --ig-name is set, or in template
+        mode when the default HL7 R4 core IG should be used.
+
+        Template mode defaults:
+            - A single aggregated FHIR API under fhir-service/ (--aggregate
+              defaults to true; use --aggregate false for one service per resource).
+            - IG profile types are embedded in a local Ballerina module under
+              fhir-service/modules/<ig-module>/ (inferred from the IG name unless
+              --ig-module-name is set). Pass --dependent-package to import a
+              published package instead and skip local IG module generation.
+
+        When no path or --ig-name is given in template mode, the tool downloads
+        hl7.fhir.r4.core into spec/international and imports the published
+        ballerinax/health.fhir.r4.international401 package (no local IG module).
+
+        When --ig-version is omitted for a registry download, the CLI lists
+        published versions interactively (TTY). Use --non-interactive in CI or
+        scripts to select dist-tags.latest automatically.
+
+        You can also obtain FHIR specification files from the respective
         Implementation Guide's official website. (Published list of
         Implementation Guides can be found in http://fhir.org/guides/registry/)
 
@@ -39,83 +66,112 @@ COMMANDS
 
             OPTIONS
                     -m, --mode <mode-type>
-                        Mode can be 'package' or 'template' or 'connector'.
-				        If the mode is set to 'package',a Ballerina package will be
-				        generated including all the records and types. If the mode is set to
-				        ‘template’, tool will generate Ballerina templates for each FHIR
-				        resource definition available in the specified path. If the mode is
-				        set to ‘connector’, a Ballerina based FHIR connector client will be
-				        generated for a given FHIR server based on its Capability Statement.
-				        This is a MANDATORY input for fhir command.
+                        Mode can be 'package', 'template', or 'connector'.
+                        In 'package' mode, a Ballerina package is generated
+                        with all records and types for the IG. In 'template'
+                        mode, Ballerina FHIR API templates are generated (by
+                        default one aggregated service under fhir-service/).
+                        In 'connector' mode, a Ballerina FHIR connector client
+                        is generated from a server's Capability Statement.
+                        This is a MANDATORY input for the fhir command.
 
                     --package-name <name-of-package>
-                        Only applicable in ‘package’ mode. Name of the Ballerina package
-                        to be generated. This is a MANDATORY input in ‘package’ mode.
+                        Only applicable in 'package' mode. Name of the Ballerina
+                        package to be generated. MANDATORY in 'package' mode.
                         Refer https://ballerina.io/learn/package-references/#the-name-field
 
                     --dependent-ig <base-url-of-the-IG>=<qualified-ballerina-package-name>
-                       This option is only applicable in ‘package’ mode and can accept multiple values.
-                       Each value must be provided as a key-value pair, where:
-                           1. <base-url-of-the-IG> is the base URL of the dependent IG.
-                           2. <qualified-ballerina-package-name> is the fully qualified name of the corresponding dependent Ballerina package.
-                           This is an optional input.
+                        Only applicable in 'package' mode; accepts multiple values.
+                        Each value is a key-value pair where:
+                            1. <base-url-of-the-IG> is the base URL of the dependent IG.
+                            2. <qualified-ballerina-package-name> is the fully qualified
+                               name of the corresponding dependent Ballerina package.
 
-                       For example, if your profile depends on the US Core profile, you should specify it like this:
-                       <base-url-of-the-IG>=<full-qualified-name-of-ballerina-package>
-                       http://hl7.org/fhir/us/core/=ballerinax/health.fhir.r4.uscore501
+                        For example, if your profile depends on US Core:
+                        http://hl7.org/fhir/us/core/=ballerinax/health.fhir.r4.uscore501
 
                     --dependent-package <qualified-ballerina-package-name>
-                        Only applicable in ‘template’ mode. Fully qualified name of the
-                        published Ballerina package containing IG resources
-                        [eg: <org>/<package>]. This option can be used to generate
-                        templates specifically for the resources in the given IG. The
-                        package name part of this value will be added as a prefix to the
-                        template name. This is a MANDATORY input in ‘template’ mode.
+                        Only applicable in 'template' mode. Import an existing
+                        published IG package (eg: <org>/<package>) instead of
+                        embedding IG resources in a local module. Disables
+                        local IG module generation. The package name is used as
+                        a prefix on generated template imports. When omitted,
+                        profile types are embedded under fhir-service/modules/.
+
+                    --ig-name <registry-package-id>
+                        FHIR package registry id (e.g. hl7.fhir.us.core).
+                        Downloads from packages.fhir.org into spec/<ig-name>
+                        when no local specification path is provided. Works in
+                        both 'package' and 'template' modes.
+
+                    --ig-version <version>
+                        Registry package version (e.g. 6.1.0 or 9.0.0). If
+                        omitted, an interactive list of published versions is
+                        shown (TTY). Use --non-interactive for dist-tags.latest.
+
+                    --non-interactive
+                        When --ig-version is omitted, use dist-tags.latest from
+                        registry metadata without prompting (for CI and scripts).
+
+                    --registry-url <url>
+                        FHIR package registry base URL (default:
+                        https://packages.fhir.org).
+
+                    --ig-cache-dir <path>
+                        Directory for cached .tgz downloads (default:
+                        .fhir-ig-cache under the working directory).
+
+                    --force-ig-download
+                        Re-download and re-extract the IG even if definitions
+                        already exist locally.
+
+                    --ig-module-name <name>
+                        Template mode only. Ballerina module name for embedded
+                        IG resources (default: inferred from the IG). Ignored
+                        when --dependent-package is set.
 
                     -o, --output <output>
-                        Location of the generated Ballerina artifacts. If this
-                        path is not specified, the output will be written to
-                        the same directory from which the command is run.
+                        Location of the generated Ballerina artifacts. If
+                        omitted, output is written to the current directory.
 
                     --org-name <org-name-of-the-package>
-                        Organization name of the Ballerina package/template to be generated.
-                        Refer https://ballerina.io/learn/package-references/#the-org-field
+                        Organization name of the generated Ballerina package or
+                        template. Refer
+                        https://ballerina.io/learn/package-references/#the-org-field
 
                     --package-version <version-of-the-package>
-                        Version of the Ballerina package/template to be generated.
+                        Version of the generated Ballerina package or template.
                         Refer https://semver.org/
 
                     --included-profile <profiles-to-included>
-                        Only applicable in ‘template’ mode. If only a specific profile/s
-                        needs to be generated as templates, specify the profile URL as the
-                        value of this parameter. This argument can be used more than once.
+                        Template mode only. Generate templates only for the
+                        given profile URL(s). May be repeated.
 
                     --excluded-profile <profiles-to-excluded>
-                        Only applicable in ‘template’ mode. If only a specific profile/s
-                        needs to be skipped when generating templates, specify the
-                        profile URL as the value of this parameter. This argument
-                        can be used more than once.
+                        Template mode only. Skip the given profile URL(s) when
+                        generating templates. May be repeated.
 
-                    --aggregate
-                        Only applicable in ‘template’ mode. Enable aggregated API mode to generate
-                        a single service with multiple FHIR resources instead of individual
-                        services for each resource.
+                    --aggregate <true|false>
+                        Template mode only. Aggregated API mode (default: true).
+                        When true, generates a single fhir-service with all
+                        resources. Set to false for one service per FHIR resource,
+                        e.g. --aggregate false.
 
                     --resources <resource1,resource2,...>
-                        Only applicable in ‘template’ mode when --aggregate is used. Comma-separated
-                        list of FHIR resources to include in the aggregated service. If not specified,
-                        all available resources will be included. Example: Patient,Observation,Encounter
+                        Template mode only when aggregation is enabled.
+                        Comma-separated list of FHIR resources to include in the
+                        aggregated service. If omitted, all available resources
+                        are included. Example: Patient,Observation,Encounter
 
                     --minimal
-                        Only applicable in 'template' mode. This flag is intended only to be used by
-                        the Health Tool MCP to generate only the core service files without
-                        additional metadata or project structure files.
+                        Template mode only. Intended for the Health Tool MCP.
+                        Generates only core service files and skips .choreo,
+                        OAS, .gitignore, and Ballerina.toml.
 
                     -c, --config <config-file-path>
-                    	This is a MANDATORY input applicable in ‘connector’ mode. Provide the path
-                    	for the configuration json file containing the necessary parameters to run the
-                    	tool in connector mode including Capability Statement URL of the FHIR server.
-                    	Sample json configuration:
+                        MANDATORY in 'connector' mode. Path to the configuration
+                        JSON file including the FHIR server Capability Statement
+                        URL. Sample configuration:
                         {
                           "config": {
                             "fhirServerUrl": "<capability-statement-url>",
@@ -131,19 +187,46 @@ COMMANDS
 
 
             EXAMPLES
-                    Generate a Ballerina package for the FHIR artifacts of USCore
-                    implementation guide.
-                        $ bal health fhir -m package --package-name uscore401 \
-                        ./path_to_uscore_definitions
+                    Generate templates from the default HL7 R4 core IG (registry
+                    download; imports ballerinax/health.fhir.r4.international401).
+                        $ bal health fhir -m template -o ./generated-template
 
-                    Generate a Ballerina package for the FHIR artifacts of
-                    USCore implementation guide and write the output
-                    to the given directory.
-                        $ bal health fhir -m package --package-name uscore401 \
-                        -o ./output_path ./path_to_uscore_definitions
+                    Generate templates from US Core via the registry (embedded IG
+                    module, aggregated service; pick version interactively).
+                        $ bal health fhir -m template --ig-name hl7.fhir.us.core \
+                        -o ./generated-template
 
-                    Generate Ballerina templates for all the FHIR resource profiles
-                    of USCore implementation guide.
+                    Pin a US Core registry version (non-interactive CI example).
+                        $ bal health fhir -m template --ig-name hl7.fhir.us.core \
+                        --ig-version 9.0.0 --non-interactive -o ./generated-template
+
+                    Generate templates using a published US Core package instead
+                    of an embedded local module.
                         $ bal health fhir -m template \
                         --dependent-package ballerinax/health.fhir.r4.uscore501 \
+                        --ig-name hl7.fhir.us.core --ig-version 6.1.0 \
+                        -o ./generated-template
+
+                    Generate separate services per FHIR resource.
+                        $ bal health fhir -m template --ig-name hl7.fhir.us.core \
+                        --aggregate false -o ./generated-template
+
+                    Generate a Ballerina package from local US Core definitions.
+                        $ bal health fhir -m package --package-name uscore401 \
                         ./path_to_uscore_definitions
+
+                    Generate a package from US Core via the FHIR package registry.
+                        $ bal health fhir -m package --package-name uscore501 \
+                        --org-name ballerinax --ig-name hl7.fhir.us.core \
+                        --ig-version 6.1.0 -o ./output
+
+                    Generate templates from local US Core definitions (embedded
+                    IG module by default).
+                        $ bal health fhir -m template \
+                        -o ./generated-template ./path_to_uscore_definitions
+
+                    Generate templates from local definitions using a published
+                    US Core package.
+                        $ bal health fhir -m template \
+                        --dependent-package ballerinax/health.fhir.r4.uscore501 \
+                        -o ./generated-template ./path_to_uscore_definitions

--- a/native/health-cli/src/main/resources/tool-config.json
+++ b/native/health-cli/src/main/resources/tool-config.json
@@ -15,7 +15,8 @@
         }
       },
       "packageMappings": {
-        "hl7.fhir.us.core": "ballerinax/health.fhir.r4.uscore501"
+        "hl7.fhir.us.core@6.1.0": "ballerinax/health.fhir.r4.uscore501",
+        "hl7.fhir.us.carin-bb.r4@2.1.0": "ballerinax/health.fhir.r4.carinbb200"
       }
     },
     "tools": {

--- a/native/health-cli/src/main/resources/tool-config.json
+++ b/native/health-cli/src/main/resources/tool-config.json
@@ -15,8 +15,10 @@
         }
       },
       "packageMappings": {
-        "hl7.fhir.us.core@6.1.0": "ballerinax/health.fhir.r4.uscore501",
-        "hl7.fhir.us.carin-bb.r4@2.1.0": "ballerinax/health.fhir.r4.carinbb200"
+        "hl7.fhir.us.core@6.1.0": "ballerinax/health.fhir.r4.uscore610",
+        "hl7.fhir.us.carin-bb.r4@2.1.0": "ballerinax/health.fhir.r4.carinbb200",
+        "hl7.fhir.us.davinci-pdex-plan-net@1.2.0": "ballerinax/health.fhir.r4.davinciplannet120",
+        "hl7.fhir.us.Davinci-drug-formulary@2.1.0": "ballerinax/health.fhir.r4.davincidrugformulary210"
       }
     },
     "tools": {

--- a/native/health-cli/src/main/resources/tool-config.json
+++ b/native/health-cli/src/main/resources/tool-config.json
@@ -1,5 +1,23 @@
 {
   "fhir": {
+    "igRegistry": {
+      "registryUrl": "https://packages.fhir.org",
+      "cacheDir": ".fhir-ig-cache",
+      "httpTimeoutSeconds": 60,
+      "defaultPackages": {
+        "r4": {
+          "name": "hl7.fhir.r4.core",
+          "version": "4.0.1"
+        },
+        "r5": {
+          "name": "hl7.fhir.r5.core",
+          "version": "5.0.0"
+        }
+      },
+      "packageMappings": {
+        "hl7.fhir.us.core": "ballerinax/health.fhir.r4.uscore501"
+      }
+    },
     "tools": {
       "package": {
         "config": {
@@ -69,10 +87,14 @@
             ]
           },
           "dependencies": [],
-          "enableAggregatedApi": false,
+          "enableAggregatedApi": true,
           "minimalGeneration": false,
           "aggregatedApis": [
           ],
+          "generateIgModule": {
+            "enabled": true,
+            "name": ""
+          },
           "builtIn": {
             "operations": [
             ],

--- a/native/health-cli/src/test/java/LocalModuleTemplateTestRunner.java
+++ b/native/health-cli/src/test/java/LocalModuleTemplateTestRunner.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import io.ballerina.cli.launcher.BLauncherException;
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+import io.ballerina.health.cmd.core.utils.HealthCmdUtils;
+import io.ballerina.health.cmd.handler.Handler;
+import io.ballerina.health.cmd.handler.HandlerFactory;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Runner that validates default embedded IG module template generation.
+ */
+public class LocalModuleTemplateTestRunner {
+
+    private static final Path EXECUTION_PATH = Paths.get(System.getProperty("user.dir"));
+
+    public static void main(String[] args) throws Exception {
+        runLocalModuleTemplateGenerationTest();
+    }
+
+    private static void runLocalModuleTemplateGenerationTest() throws URISyntaxException, BallerinaHealthException {
+        Map<String, Object> argsMap = new HashMap<>();
+        argsMap.put("--package-name", "uscore501");
+        argsMap.put("--org-name", "ballerinax");
+        argsMap.put("--package-version", "1.1.0");
+        argsMap.put("--included-profile", null);
+        argsMap.put("--excluded-profile", null);
+        argsMap.put("--explicit-dependent-package", false);
+        argsMap.put("--dependent-package", null);
+        argsMap.put("--ig-module-name", "localprofile");
+        argsMap.put("--dependent-ig", null);
+        argsMap.put("--aggregate", true);
+        argsMap.put("--resources", "Patient");
+        argsMap.put("--minimal", false);
+
+        String mode = "template";
+        String command = "fhir";
+
+        String resourcePath = Paths.get(
+                Objects.requireNonNull(LocalModuleTemplateTestRunner.class.getClassLoader().getResource("io")).toURI()
+        ).getParent().getParent().toString() + File.separator + "test-classes" + File.separator + "profiles.USCore";
+        Path specificationPath = HealthCmdUtils.validateAndSetSpecificationPath(resourcePath, EXECUTION_PATH.toString());
+        Path outputPath = Paths.get(resourcePath).getParent().resolve("local-module-template-test");
+        cleanOutputDirectory(outputPath);
+
+        Handler toolHandler;
+        try {
+            toolHandler = HandlerFactory.createHandler(command, mode, System.out, specificationPath.toString());
+        } catch (BallerinaHealthException e) {
+            throw new BLauncherException();
+        }
+        toolHandler.setArgs(argsMap);
+        boolean executionStatus = toolHandler.execute(specificationPath.toString(), outputPath.toString());
+        if (!executionStatus) {
+            throw new RuntimeException("Local module template generation failed");
+        }
+
+        Path servicePath = outputPath.resolve("fhir-service").resolve("service.bal");
+        Path localModuleInitializerPath = outputPath.resolve("fhir-service")
+                .resolve("modules")
+                .resolve("localprofile")
+                .resolve("initializer.bal");
+
+        if (!Files.exists(servicePath)) {
+            throw new RuntimeException("Generated aggregated service not found: " + servicePath);
+        }
+        if (!Files.exists(localModuleInitializerPath)) {
+            throw new RuntimeException("Generated IG module not found: " + localModuleInitializerPath);
+        }
+
+        try {
+            String serviceContent = Files.readString(servicePath);
+            if (!serviceContent.contains("localprofile:")) {
+                throw new RuntimeException("Generated service does not use generated IG module imports");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed validating generated service content", e);
+        }
+    }
+
+    private static void cleanOutputDirectory(Path outputPath) {
+        File file = outputPath.toFile();
+        if (!file.exists()) {
+            return;
+        }
+        delete(file);
+    }
+
+    private static void delete(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    delete(child);
+                }
+            }
+        }
+        if (!file.delete()) {
+            throw new RuntimeException("Failed to delete test artifact: " + file.getAbsolutePath());
+        }
+    }
+}

--- a/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/CommonUtilTest.java
+++ b/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/CommonUtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import org.junit.jupiter.api.Test;
+import org.wso2.healthcare.fhir.ballerina.packagegen.tool.utils.GeneratorUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CommonUtilTest {
+
+    @Test
+    void stripCanonicalVersionRemovesVersionSuffix() {
+        assertEquals("http://hl7.org/fhir/StructureDefinition/SimpleQuantity",
+                org.wso2.healthcare.fhir.ballerina.packagegen.tool.utils.CommonUtil.stripCanonicalVersion(
+                        "http://hl7.org/fhir/StructureDefinition/SimpleQuantity|4.0.1"));
+    }
+
+    @Test
+    void getUniqueIdentifierFromVersionedProfileTypeDoesNotProduceDots() {
+        assertEquals("SimpleQuantity",
+                GeneratorUtils.getInstance().getUniqueIdentifierFromId("SimpleQuantity|4.0.1"));
+    }
+}

--- a/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloaderTest.java
+++ b/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloaderTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import io.ballerina.health.cmd.core.exception.BallerinaHealthException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FhirIgPackageDownloaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void extractPackageWritesStructureDefinitionJson() throws Exception {
+        byte[] tgz = buildSamplePackageTgz();
+        Path target = tempDir.resolve("extracted");
+        FhirIgPackageDownloader.extractPackage(tgz, target);
+
+        Path patientSd = target.resolve("StructureDefinition-Patient.json");
+        assertTrue(Files.exists(patientSd));
+        String content = Files.readString(patientSd);
+        assertTrue(content.contains("\"resourceType\": \"StructureDefinition\""));
+        assertTrue(SpecificationPathUtils.containsStructureDefinitionResources(target));
+    }
+
+    @Test
+    void downloadAndExtractSkipsWhenDefinitionsPresent() throws Exception {
+        Path target = tempDir.resolve("cached-ig");
+        Files.createDirectories(target);
+        Files.writeString(target.resolve("StructureDefinition-Patient.json"), """
+                {
+                  "resourceType": "StructureDefinition",
+                  "url": "http://hl7.org/fhir/StructureDefinition/Patient",
+                  "name": "Patient",
+                  "type": "Patient",
+                  "kind": "resource",
+                  "fhirVersion": "4.0.1"
+                }
+                """);
+
+        FhirIgPackageDownloader.DownloadOptions options = new FhirIgPackageDownloader.DownloadOptions(
+                "https://packages.fhir.org", tempDir.resolve("cache").toString(), 60, false);
+        Path result = FhirIgPackageDownloader.downloadAndExtract(
+                target, "hl7.fhir.r4.core", "4.0.1", options);
+        assertEquals(target, result);
+    }
+
+    @Test
+    void parseIgSpecUsesLatestSentinelWhenVersionMissing() {
+        FhirIgPackageDownloader.ParsedIgSpec spec =
+                FhirIgPackageDownloader.parseIgSpec("hl7.fhir.us.core", null);
+        assertEquals("hl7.fhir.us.core", spec.name());
+        assertEquals("latest", spec.version());
+    }
+
+    @Test
+    void parseLatestVersionFromMetadata() throws Exception {
+        String metadata = """
+                {
+                  "name": "hl7.fhir.us.core",
+                  "dist-tags": { "latest": "9.0.0" }
+                }
+                """;
+        assertEquals("9.0.0",
+                FhirIgPackageDownloader.parseLatestVersionFromMetadata(metadata, "hl7.fhir.us.core"));
+    }
+
+    @Test
+    void parseLatestVersionFromMetadataMissingDistTags() {
+        assertThrows(BallerinaHealthException.class, () ->
+                FhirIgPackageDownloader.parseLatestVersionFromMetadata("{\"name\":\"x\"}", "x"));
+    }
+
+    @Test
+    void resolvePackageVersionKeepsExplicitVersion() throws Exception {
+        FhirIgPackageDownloader.DownloadOptions options = new FhirIgPackageDownloader.DownloadOptions(
+                "https://packages.fhir.org", tempDir.resolve("cache").toString(), 60, false, true, null);
+        assertEquals("6.1.0", FhirIgPackageDownloader.resolvePackageVersion(
+                "https://packages.fhir.org", "hl7.fhir.us.core", "6.1.0", options));
+    }
+
+    @Test
+    void sanitizeIgDirectoryName() {
+        assertEquals("hl7_fhir_us_core", FhirIgPackageDownloader.sanitizeIgDirectoryName("hl7.fhir.us.core"));
+    }
+
+    private static byte[] buildSamplePackageTgz() throws IOException {
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzipOut = new GZIPOutputStream(byteOut);
+             TarArchiveOutputStream tarOut = new TarArchiveOutputStream(gzipOut)) {
+            addTarEntry(tarOut, "package/package.json", """
+                    {"name":"test.package","version":"1.0.0","fhirVersions":["4.0.1"]}
+                    """);
+            addTarEntry(tarOut, "package/StructureDefinition-Patient.json", """
+                    {
+                      "resourceType": "StructureDefinition",
+                      "url": "http://hl7.org/fhir/StructureDefinition/Patient",
+                      "name": "Patient",
+                      "type": "Patient",
+                      "kind": "resource",
+                      "fhirVersion": "4.0.1"
+                    }
+                    """);
+            tarOut.finish();
+        }
+        return byteOut.toByteArray();
+    }
+
+    private static void addTarEntry(TarArchiveOutputStream tarOut, String name, String content) throws IOException {
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        TarArchiveEntry entry = new TarArchiveEntry(name);
+        entry.setSize(bytes.length);
+        tarOut.putArchiveEntry(entry);
+        tarOut.write(bytes);
+        tarOut.closeArchiveEntry();
+    }
+}

--- a/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloaderTest.java
+++ b/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloaderTest.java
@@ -118,6 +118,37 @@ class FhirIgPackageDownloaderTest {
     }
 
     @Test
+    void downloadAndExtractRefetchesWhenInstalledVersionDiffers() throws Exception {
+        Path target = tempDir.resolve("stale-ig");
+        Files.createDirectories(target);
+        Files.writeString(target.resolve("package.json"), "{\"name\":\"hl7.fhir.us.core\",\"version\":\"6.1.0\"}");
+        Files.writeString(target.resolve("StructureDefinition-Patient.json"), """
+                {
+                  "resourceType": "StructureDefinition",
+                  "url": "http://hl7.org/fhir/StructureDefinition/Patient",
+                  "name": "StalePatient"
+                }
+                """);
+
+        Path cacheDir = tempDir.resolve("mismatch-cache");
+        Files.createDirectories(cacheDir);
+        Files.write(cacheDir.resolve("hl7.fhir.us.core-9.0.0.tgz"), buildSamplePackageTgz());
+
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        FhirIgPackageDownloader.DownloadOptions options = new FhirIgPackageDownloader.DownloadOptions(
+                "https://packages.fhir.org", cacheDir.toString(), 60, false, false, false, true,
+                new PrintStream(buffer));
+
+        Path result = FhirIgPackageDownloader.downloadAndExtract(target, "hl7.fhir.us.core", "9.0.0", options);
+
+        assertEquals(target, result);
+        String content = Files.readString(target.resolve("StructureDefinition-Patient.json"));
+        assertTrue(content.contains("\"name\": \"Patient\""));
+        assertTrue(!content.contains("StalePatient"));
+        assertTrue(buffer.toString(StandardCharsets.UTF_8).contains("[WARN] Replacing existing IG definitions"));
+    }
+
+    @Test
     void parseIgReferenceSplitsNameAndVersion() {
         FhirIgPackageDownloader.ParsedIgSpec spec =
                 FhirIgPackageDownloader.parseIgReference("hl7.fhir.us.core@8.0.1");

--- a/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloaderTest.java
+++ b/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/FhirIgPackageDownloaderTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -105,7 +106,8 @@ class FhirIgPackageDownloaderTest {
     @Test
     void resolvePackageVersionKeepsExplicitVersion() throws Exception {
         FhirIgPackageDownloader.DownloadOptions options = new FhirIgPackageDownloader.DownloadOptions(
-                "https://packages.fhir.org", tempDir.resolve("cache").toString(), 60, false, true, null);
+                "https://packages.fhir.org", tempDir.resolve("cache").toString(), 60, false, true, false, true,
+                null);
         assertEquals("6.1.0", FhirIgPackageDownloader.resolvePackageVersion(
                 "https://packages.fhir.org", "hl7.fhir.us.core", "6.1.0", options));
     }
@@ -113,6 +115,62 @@ class FhirIgPackageDownloaderTest {
     @Test
     void sanitizeIgDirectoryName() {
         assertEquals("hl7_fhir_us_core", FhirIgPackageDownloader.sanitizeIgDirectoryName("hl7.fhir.us.core"));
+    }
+
+    @Test
+    void parseIgReferenceSplitsNameAndVersion() {
+        FhirIgPackageDownloader.ParsedIgSpec spec =
+                FhirIgPackageDownloader.parseIgReference("hl7.fhir.us.core@8.0.1");
+        assertEquals("hl7.fhir.us.core", spec.name());
+        assertEquals("8.0.1", spec.version());
+    }
+
+    @Test
+    void parseIgReferenceWithoutVersionUsesLatestSentinel() {
+        FhirIgPackageDownloader.ParsedIgSpec spec =
+                FhirIgPackageDownloader.parseIgReference("hl7.fhir.us.core");
+        assertEquals("hl7.fhir.us.core", spec.name());
+        assertEquals("latest", spec.version());
+    }
+
+    @Test
+    void parseIgReferenceSplitsOnLastAtSign() {
+        FhirIgPackageDownloader.ParsedIgSpec spec = FhirIgPackageDownloader.parseIgReference("foo@bar@1.0.0");
+        assertEquals("foo@bar", spec.name());
+        assertEquals("1.0.0", spec.version());
+    }
+
+    @Test
+    void isValidIgReferenceRejectsMissingName() {
+        assertTrue(!FhirIgPackageDownloader.isValidIgReference("@8.0.1"));
+        assertTrue(!FhirIgPackageDownloader.isValidIgReference(""));
+        assertTrue(!FhirIgPackageDownloader.isValidIgReference(null));
+    }
+
+    @Test
+    void isValidIgReferenceAcceptsBareNameOrNameAtVersion() {
+        assertTrue(FhirIgPackageDownloader.isValidIgReference("hl7.fhir.us.core"));
+        assertTrue(FhirIgPackageDownloader.isValidIgReference("hl7.fhir.us.core@8.0.1"));
+    }
+
+    @Test
+    void fetchesFromCacheWithoutNetworkOrWarningWhenPreSeeded() throws Exception {
+        byte[] tgz = buildSamplePackageTgz();
+        Path cacheDir = tempDir.resolve("cache");
+        Files.createDirectories(cacheDir);
+        Files.write(cacheDir.resolve("hl7.fhir.r4.core-4.0.1.tgz"), tgz);
+
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        FhirIgPackageDownloader.DownloadOptions options = new FhirIgPackageDownloader.DownloadOptions(
+                "https://packages.fhir.org", cacheDir.toString(), 60, false, false, true, true,
+                new PrintStream(buffer));
+
+        Path target = tempDir.resolve("extracted-from-cache");
+        Path result = FhirIgPackageDownloader.downloadAndExtract(target, "hl7.fhir.r4.core", "4.0.1", options);
+
+        assertEquals(target, result);
+        assertTrue(Files.exists(target.resolve("StructureDefinition-Patient.json")));
+        assertEquals(0, buffer.size(), "pre-seeded cache hit should need no network call and print no warning");
     }
 
     private static byte[] buildSamplePackageTgz() throws IOException {

--- a/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/IgVersionSelectorTest.java
+++ b/native/health-cli/src/test/java/io/ballerina/health/cmd/core/utils/IgVersionSelectorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.health.cmd.core.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IgVersionSelectorTest {
+
+    private static final String US_CORE_METADATA = """
+            {
+              "name": "hl7.fhir.us.core",
+              "dist-tags": { "latest": "9.0.0" },
+              "versions": {
+                "6.1.0": { "fhirVersion": "4.0.1" },
+                "9.0.0": { "fhirVersion": "4.0.1" },
+                "9.0.0-ballot": { "fhirVersion": "4.0.1" }
+              }
+            }
+            """;
+
+    @Test
+    void parseAvailableVersionsReturnsNewestFirst() throws Exception {
+        List<String> versions = IgVersionSelector.parseAvailableVersions(US_CORE_METADATA);
+        assertEquals(3, versions.size());
+        assertEquals("9.0.0", versions.get(0));
+        assertTrue(versions.contains("6.1.0"));
+    }
+
+    @Test
+    void selectVersionNonInteractiveUsesLatestTag() throws Exception {
+        List<String> versions = IgVersionSelector.parseAvailableVersions(US_CORE_METADATA);
+        String selected = IgVersionSelector.selectVersion(
+                "hl7.fhir.us.core", versions, "9.0.0", true, null);
+        assertEquals("9.0.0", selected);
+    }
+
+    @Test
+    void selectVersionNonInteractiveFallsBackToFirstWhenLatestMissing() throws Exception {
+        List<String> versions = List.of("6.1.0", "5.0.0");
+        String selected = IgVersionSelector.selectVersion(
+                "hl7.fhir.us.core", versions, null, true, null);
+        assertEquals("6.1.0", selected);
+    }
+
+    @Test
+    void compareVersionsOrdersNumericSegments() {
+        assertTrue(IgVersionSelector.compareVersionsDesc("9.0.0", "6.1.0") < 0);
+        assertTrue(IgVersionSelector.compareVersionsDesc("9.0.0-ballot", "9.0.0") > 0);
+    }
+
+    @Test
+    void selectVersionNonInteractiveDoesNotWritePrompt() throws Exception {
+        List<String> versions = IgVersionSelector.parseAvailableVersions(US_CORE_METADATA);
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        PrintStream capture = new PrintStream(buffer);
+        IgVersionSelector.selectVersion("hl7.fhir.us.core", versions, "9.0.0", true, capture);
+        assertEquals(0, buffer.size());
+    }
+
+    @Test
+    void isInteractiveConsoleUnavailableInJUnit() {
+        assertFalse(IgVersionSelector.isInteractiveConsoleAvailable());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>io.ballerina</groupId>
     <artifactId>health-tools</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 
     <packaging>pom</packaging>
     <modules>


### PR DESCRIPTION
## Description

This builds on #139 (*Add FHIR registry pointed package/template generation support* by @sameeragunarathne), which adds the ability to download FHIR Implementation Guides directly from the registry (packages.fhir.org) instead of requiring a pre-downloaded local spec directory.

On top of that base, this PR:

- **Simplifies the CLI surface**: replaces `--ig-name`, `--ig-version`, and `--non-interactive` with a single npm-style `--ig=<name>[@version]` flag (e.g. `--ig hl7.fhir.us.core@8.0.1`), matching how this repo's own MCP docs already reference FHIR registry packages, and the registry's own npm-shaped protocol. Non-interactive behavior is now auto-detected (no TTY -> latest version, via the existing console-availability check in `IgVersionSelector`) instead of requiring an explicit flag.
- **Adds two opt-in warnings around `--ig-cache-dir`**:
  - When `--ig-cache-dir` is explicitly set and the expected `<name>-<version>.tgz` isn't found there, a warning is printed before falling back to a registry download, instead of silently reaching out to the network.
  - After a fresh download actually writes into the cache directory, a warning reminds you to add it to `.gitignore` (skipped when the cache directory is an absolute path outside the project).
- **Fixes a version-mismatch bug** in `downloadAndExtract()`: switching `--ig` versions in the same working directory (e.g. `hl7.fhir.us.core` -> `hl7.fhir.us.core@6.1.0`) previously reused stale content silently, since the target-directory short-circuit never checked which version was actually on disk. Confirmed via live end-to-end testing against the real registry. Now compares the on-disk `package.json` version against the requested one and re-fetches on mismatch, with a warning explaining why.
- **Generates per-profile search dispatch skeletons for resource types shared by more than one profile** — e.g. US Core's ~26 profiles of `Observation` previously all collapsed into one generic search stub (the union return type was already correct; nothing helped route a request to the right profile). Now, only when a resource type has more than one attached profile, the generator adds one named `search<ProfileName>` stub per profile plus a `match` on the incoming `_profile` search parameter dispatching to the right one, falling back to the existing generic stub when `_profile` is absent or unmatched. Single-profile resource types are untouched. Verified by generating from a real multi-profile IG (US Core) in both the default aggregated and per-resource template modes and compiling the output with `bal build`.
- **Adds multi-IG generation**: `--ig` is now repeatable in template mode (e.g. `--ig hl7.fhir.us.carin-bb.r4@2.1.0 --ig hl7.fhir.us.davinci-pdex-plan-net@1.2.0`) to merge profiles from *different* IGs for the same resource type onto one service, dispatched by `_profile` -- a direct generalization of the per-profile dispatch mechanism above (same mechanism, now fed more than one IG). Root cause of why this didn't already work: the codegen framework never auto-discovers IG subfolders on its own -- it only ever processes the IGs it's explicitly told about by name and directory, and the CLI previously always told it about exactly one, hardcoded to the literal name `"FHIR"`. Every IG in a multi-IG run must resolve via `packageMappings` (auto-applied for this path only -- see below); `--dependent-package` and mixed FHIR versions aren't supported here. Verified end-to-end against the real motivating case (CARIN BB + Da Vinci PDex Plan-Net `Organization`/`Practitioner`, matching a real hand-written facade project's services) with `bal build`, plus regression-tested against single-IG (embed mode, explicit `--dependent-package`) and no-`--ig` default-international-base generation to confirm none of those changed behavior.
- **Adds `--flat`** to generate aggregated-mode templates directly into `-o` instead of nesting under `fhir-service/`. Unlike `--minimal` (which also flattens, but drops `Ballerina.toml`/`.gitignore`/OAS/`.choreo`), `--flat` only changes where the output lands and keeps the full project scaffolding. Default (no `--flat`) behavior is unchanged; no effect with `--aggregate false`, where each resource already gets its own directory under `-o`.
- **Wires `--package-name` to actually name aggregated template projects.** The flag already existed and was read in template mode, but was only ever used to name an internal scratch package (the embedded-IG-module intermediate) — the generated project itself was always hardcoded to `FHIRServerTemplate` in `Ballerina.toml`, regardless of what was passed. Now `--package-name` (when given) sets the real project name, and the embedded IG module's import prefix is kept in sync with it so the generated code still compiles. Defaults to `FHIRServerTemplate` when omitted, so existing behavior is unchanged.
- **Fixes the copyright year in generated templates being hardcoded and stale** (`2025`, already wrong). `fhir-to-bal-lib` and `fhir-to-bal-connector` already solve this correctly with a `${licenseYear}` variable computed at generation time; this applies that same existing pattern to `fhir-to-bal-template`'s three templates instead of leaving a static year. No new flag — every generated file now just carries the actual current year.
- Updates the MCP server (`mcp/health-tool-mcp/server.py`) and the CLI help text (`ballerina-health.help`) to match.
- **Makes `packageMappings` version-aware**, keyed by `<igName>@<igVersion>` instead of bare IG name. The old bare-name key meant a mapping intended for one specific IG version silently matched *any* requested version — confirmed live (the `hl7.fhir.us.core` entry used to fire even when `--ig` resolved to latest/`9.0.0`, not just its intended `6.1.0`). Four confirmed mappings are in `tool-config.json` now (US Core, CARIN BB, Da Vinci PDex Plan-Net, Da Vinci Drug Formulary). For a single `--ig` this stays advisory-only (prints a suggestion, does not auto-apply `--dependent-package` — that decision is still open, see Known follow-ups); for multi-IG generation it's required and auto-applied per IG, since there's no other way to end up with a mixed set of dependent packages.
- Adds `CLAUDE.md`/`AGENTS.md` (neither existed before) capturing the architectural knowledge accumulated while building this PR — the registry-download caching model, two non-obvious Ballerina/framework constraints on the generated templates, and the fact that template-mode generation has no automated test coverage and can only be verified by actually generating and running `bal build`.

## Examples

```shell
# Generate a Ballerina package from the latest release of an IG on the registry --
# no local spec directory needed
bal health fhir -m package --package-name uscore --ig hl7.fhir.us.core -o ./uscore-pkg

# Pin an exact registry version instead of "latest"
bal health fhir -m package --package-name uscore --ig hl7.fhir.us.core@6.1.0 -o ./uscore-pkg

# Generate templates: aggregated by default, IG embedded as a local module. Resource
# types profiled more than once in the IG (e.g. Observation in US Core) automatically
# get a search dispatch skeleton -- no extra flag needed.
bal health fhir -m template --ig hl7.fhir.us.core -o ./uscore-templates

# Same, but written directly into -o instead of ./uscore-templates/fhir-service/,
# keeping Ballerina.toml/.gitignore/OAS/.choreo
bal health fhir -m template --ig hl7.fhir.us.core --flat -o ./uscore-templates

# Name the generated aggregated project instead of the default "FHIRServerTemplate"
bal health fhir -m template --ig hl7.fhir.us.core --package-name p_access --flat -o ./p-access

# Point at an already-downloaded IG package instead of hitting the registry
# (expects ./my-cache/hl7.fhir.us.core-6.1.0.tgz)
bal health fhir -m template --ig hl7.fhir.us.core@6.1.0 --ig-cache-dir ./my-cache -o ./uscore-templates

# Force a fresh re-download even if definitions already exist locally
bal health fhir -m template --ig hl7.fhir.us.core --force-ig-download -o ./uscore-templates

# Generate separate per-resource services instead of one aggregated service
bal health fhir -m template --ig hl7.fhir.us.core --aggregate false -o ./uscore-templates

# Merge profiles from two different IGs for the same resource type (e.g. Organization)
# into one service, dispatched by _profile -- both IGs need a packageMappings entry
bal health fhir -m template --ig hl7.fhir.us.carin-bb.r4@2.1.0 --ig hl7.fhir.us.davinci-pdex-plan-net@1.2.0 -o ./merged-templates
```

## Test plan
- [x] `mvn clean install` — full reactor build, all modules pass
- [x] `mvn -pl native/health-cli -am test` — 21 JUnit tests pass (14 in `FhirIgPackageDownloaderTest`, covering `--ig` parsing, cache pre-seeding, and the version-mismatch fix)
- [x] Live smoke test against the real registry (`bal health fhir -m package/template --ig hl7.fhir.us.core[@version] ...`): invalid `--ig` rejected cleanly, bare-name latest resolution, explicit version pinning, cache-miss/hit warnings, gitignore reminder, and the version-switch fix all verified end-to-end
- [x] Generated a real multi-profile resource type (US Core `Observation`, 26 profiles) in both aggregated and per-resource template modes and compiled the output directly with `bal build` — clean compile in both. Compiled a single-profile resource type (`Patient`) from the same run to confirm it's unaffected.
- [x] Verified `--flat` live: default invocation still nests under `fhir-service/`; `--flat` generates directly into `-o` with `Ballerina.toml`/`.gitignore`/`.choreo`/`oas/` all present, and the result compiles cleanly with `bal build`.
- [x] Verified `--package-name` live: default invocation still produces `FHIRServerTemplate`; `--package-name p_access` produces a project named `p_access` with a matching `import p_access.<ig_module>;` statement, and the result compiles cleanly with `bal build`.
- [x] Verified the license year live in both aggregated and per-resource template modes: generated `service.bal`/`*_api_config.bal` now carry the actual current year instead of the previously hardcoded `2025`.
- [x] Verified multi-IG generation live against the real registry (CARIN BB + Da Vinci PDex Plan-Net): merged `Organization`/`Practitioner` compile cleanly with `bal build` with correct per-profile imports and dispatch; also regression-tested single-IG embed mode, single-IG with explicit `--dependent-package`, and no-`--ig` default-international-base generation against the same change to confirm no behavior changed there (confirmed one unrelated pre-existing bug via `git stash` comparison — see Known follow-ups — not caused by this change).

## Known follow-ups (not in this PR)
- Whether a `packageMappings` match should **auto-apply** `--dependent-package` for a *single* `--ig` (the way it now does, required, for multi-IG) is still an open decision, not yet made.
- CDS mode's `cdsBalService.vm` copyright header is written entirely as Velocity line-comments (`##`), so it's stripped at render time — CDS-generated files currently ship with no copyright header at all. Independent of anything in this PR; flagged for a separate fix.
- Multi-IG generation doesn't support mixing an IG with a known `packageMappings` entry and an IG without one in the same run (every IG must have a mapping, or the whole run fails) -- no "embed some, import others" support yet.
- Multi-IG generation doesn't validate mixed FHIR versions (an r4 IG merged with an r5 IG) -- nothing rejects this today.
- Found and confirmed (via `git stash` comparison against the commit before this PR's multi-IG work) a pre-existing, unrelated bug: generating from the raw international-base spec in aggregated mode hits `redeclared symbol 'searchExampleLipidProfile'` at `bal build` time -- the per-profile dispatch-skeleton stub functions (added earlier in this PR) are named by profile name alone with no resource-type qualification, so two different resource types sharing a same-named example profile collide. Not fixed here; needs the stub name qualified by resource type.
- Fully customizable copyright/license text (e.g. pointing the CLI at a `.txt` file) is not implemented — current state is per-module hardcoded text with only the year being dynamic. Would touch ~20 templates across all four generator modules if pursued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
